### PR TITLE
Moved <script> into <body>, removed .focus()

### DIFF
--- a/javascript/introduction-to-js-1/variables/index.html
+++ b/javascript/introduction-to-js-1/variables/index.html
@@ -55,9 +55,6 @@
   </head>
   <body>
 
-    
-  </body>
-
   <script>
     var geval = eval;
     function createInput() {
@@ -70,7 +67,6 @@
       inputDiv.appendChild(inputPara);
       inputDiv.appendChild(inputForm);
       document.body.appendChild(inputDiv);
-      inputForm.focus();
 
       inputForm.addEventListener('change', executeCode);
     }
@@ -98,6 +94,7 @@
     
     createInput();
 
-
   </script>
+    
+  </body>
 </html>


### PR DESCRIPTION
Moved <script> element into <body> element following W3C recommendations; removed inputForm.focus(), which caused the page at https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math to jump past the first few paragraphs of content to the console whenever newly accessed.