### PR TITLE
changed btn.onmouseout to btn.onclick

### DIFF
--- a/javascript/building-blocks/events/random-color-eventhandlerproperty.html
+++ b/javascript/building-blocks/events/random-color-eventhandlerproperty.html
@@ -23,7 +23,7 @@
         document.body.style.backgroundColor = rndCol;
       }
 
-      btn.onmouseout = bgChange;    
+      btn.onclick = bgChange;    
     </script>
   </body>
 </html>


### PR DESCRIPTION
The article specifies to change btn.onclick to different values, but there is no btn.onclick. I believe it was meant to have btn.onmouseout be as btn.onclick. The user is supposed to change it to btn.onmouseout later in the experiment.