### PR TITLE
Move <script> tag before the closing </body>.

### DIFF
--- a/html/introduction-to-html/the-html-head/css-and-js.html
+++ b/html/introduction-to-html/the-html-head/css-and-js.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Meta examples</title>
-    
+
     <meta name="author" content="Chris Mills">
     <meta name="description" content="This is an example page to demonstrate usage of metadata on web pages.">
 
@@ -19,6 +19,7 @@
     <h1>Meta examples</h1>
 
     <p>Japanese example: ご飯が熱い。</p>
+
+    <script src="script.js"></script>
   </body>
-  <script src="script.js"></script>
 </html>

--- a/javascript/apis/document-manipulation/dom-example-manipulated.html
+++ b/javascript/apis/document-manipulation/dom-example-manipulated.html
@@ -14,31 +14,32 @@
     </style>
   </head>
   <body>
-      <section>
-        <img src="dinosaur.png" alt="A red Tyrannosaurus Rex: A two legged dinosaur standing upright like a human, with small arms, and a large head with lots of sharp teeth.">
-        <p>Here we will add a link to the <a href="https://www.mozilla.org/">Mozilla homepage</a></p>
-      </section>
+    <section>
+      <img src="dinosaur.png" alt="A red Tyrannosaurus Rex: A two legged dinosaur standing upright like a human, with small arms, and a large head with lots of sharp teeth.">
+      <p>Here we will add a link to the <a href="https://www.mozilla.org/">Mozilla homepage</a></p>
+    </section>
+
+    <script>
+      var link = document.querySelector('a');
+      link.textContent = 'Mozilla Developer Network';
+      link.href = 'https://developer.mozilla.org';
+
+      var sect = document.querySelector('section');
+      var para = document.createElement('p');
+      para.textContent = 'We hope you enjoyed the ride.';
+      sect.appendChild(para);
+
+      var text = document.createTextNode(' — the premier source for web development knowledge.');
+      var linkPara = document.querySelector('p');
+      linkPara.appendChild(text);
+
+      // You could clone link para by doing something like this and inserting the new para instead
+      // var newPara = linkPara.cloneNode(true);
+
+      sect.appendChild(linkPara);
+      linkPara.parentNode.removeChild(linkPara);
+
+      para.setAttribute('class', 'highlight');
+    </script>
   </body>
-  <script>
-    var link = document.querySelector('a');
-    link.textContent = 'Mozilla Developer Network';
-    link.href = 'https://developer.mozilla.org';
-
-    var sect = document.querySelector('section');
-    var para = document.createElement('p');
-    para.textContent = 'We hope you enjoyed the ride.';
-    sect.appendChild(para);
-
-    var text = document.createTextNode(' — the premier source for web development knowledge.');
-    var linkPara = document.querySelector('p');
-    linkPara.appendChild(text);
-
-    // You could clone link para by doing something like this and inserting the new para instead
-    // var newPara = linkPara.cloneNode(true);
-
-    sect.appendChild(linkPara);
-    linkPara.parentNode.removeChild(linkPara);
-
-    para.setAttribute('class', 'highlight');
-  </script>
 </html>

--- a/javascript/apis/document-manipulation/shopping-list-finished.html
+++ b/javascript/apis/document-manipulation/shopping-list-finished.html
@@ -29,34 +29,31 @@
 
     </ul>
 
+    <script>
+      var list = document.querySelector('ul');
+      var input = document.querySelector('input');
+      var button = document.querySelector('button');
+
+      button.onclick = function() {
+        var myItem = input.value;
+        input.value = '';
+
+        var listItem = document.createElement('li');
+        var listText = document.createElement('span');
+        var listBtn = document.createElement('button');
+
+        listItem.appendChild(listText);
+        listText.textContent = myItem;
+        listItem.appendChild(listBtn);
+        listBtn.textContent = 'Delete';
+        list.appendChild(listItem);
+
+        listBtn.onclick = function(e) {
+          list.removeChild(listItem);
+        }
+
+        input.focus();
+      }
+    </script>
   </body>
-  <script>
-
-  var list = document.querySelector('ul');
-  var input = document.querySelector('input');
-  var button = document.querySelector('button');
-
-  button.onclick = function() {
-    var myItem = input.value;
-    input.value = '';
-
-    var listItem = document.createElement('li');
-    var listText = document.createElement('span');
-    var listBtn = document.createElement('button');
-
-    listItem.appendChild(listText);
-    listText.textContent = myItem;
-    listItem.appendChild(listBtn);
-    listBtn.textContent = 'Delete';
-    list.appendChild(listItem);
-
-    listBtn.onclick = function(e) {
-      list.removeChild(listItem);
-    }
-
-    input.focus();
-  }
-
-
-  </script>
 </html>

--- a/javascript/apis/document-manipulation/shopping-list.html
+++ b/javascript/apis/document-manipulation/shopping-list.html
@@ -29,8 +29,8 @@
 
     </ul>
 
-  </body>
-  <script>
+    <script>
 
-  </script>
+    </script>
+  </body>
 </html>

--- a/javascript/apis/document-manipulation/window-resize-example-finished.html
+++ b/javascript/apis/document-manipulation/window-resize-example-finished.html
@@ -23,20 +23,20 @@
 
     </div>
 
-  </body>
-  <script>
-    var div = document.querySelector('div');
-    var WIDTH = window.innerWidth;
-    var HEIGHT = window.innerHeight;
+    <script>
+      var div = document.querySelector('div');
+      var WIDTH = window.innerWidth;
+      var HEIGHT = window.innerHeight;
 
-    div.style.width = WIDTH + 'px';
-    div.style.height = HEIGHT + 'px';
-
-    window.onresize = function() {
-      WIDTH = window.innerWidth;
-      HEIGHT = window.innerHeight;
       div.style.width = WIDTH + 'px';
       div.style.height = HEIGHT + 'px';
-    }
-  </script>
+
+      window.onresize = function() {
+        WIDTH = window.innerWidth;
+        HEIGHT = window.innerHeight;
+        div.style.width = WIDTH + 'px';
+        div.style.height = HEIGHT + 'px';
+      }
+    </script>
+  </body>
 </html>

--- a/javascript/apis/document-manipulation/window-resize-example.html
+++ b/javascript/apis/document-manipulation/window-resize-example.html
@@ -23,8 +23,8 @@
 
     </div>
 
-  </body>
-  <script>
+    <script>
 
-  </script>
+    </script>
+  </body>
 </html>

--- a/javascript/introduction-to-js-1/what-is-js/javascript-label.html
+++ b/javascript/introduction-to-js-1/what-is-js/javascript-label.html
@@ -1,36 +1,36 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
-<head>
-  <title>JavaScript label example</title>
-  <style>
-    p {
-      font-family: 'helvetica neue', helvetica, sans-serif;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      text-align: center;
-      border: 2px solid rgba(0,0,200,0.6);
-      background: rgba(0,0,200,0.3);
-      color: rgba(0,0,200,0.6);
-      box-shadow: 1px 1px 2px rgba(0,0,200,0.4);
-      border-radius: 10px;
-      padding: 3px 10px;
-      display: inline-block;
-      cursor: pointer;
-    }
-  </style>
-</head>
-<body>
-  <p>Player 1: Chris</p>
-</body>
-<script>
-var para = document.querySelector('p');
+  <head>
+    <title>JavaScript label example</title>
+    <style>
+      p {
+        font-family: 'helvetica neue', helvetica, sans-serif;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        text-align: center;
+        border: 2px solid rgba(0,0,200,0.6);
+        background: rgba(0,0,200,0.3);
+        color: rgba(0,0,200,0.6);
+        box-shadow: 1px 1px 2px rgba(0,0,200,0.4);
+        border-radius: 10px;
+        padding: 3px 10px;
+        display: inline-block;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Player 1: Chris</p>
 
-para.addEventListener('click', updateName);
+    <script>
+      var para = document.querySelector('p');
 
-function updateName() {
-  var name = prompt('Enter a new name');
-  para.textContent = 'Player 1: ' + name;
-}
-</script>
+      para.addEventListener('click', updateName);
 
+      function updateName() {
+        var name = prompt('Enter a new name');
+        para.textContent = 'Player 1: ' + name;
+      }
+    </script>
+  </body>
 </html>

--- a/tools-testing/cross-browser-testing/javascript/bad-for-loop.html
+++ b/tools-testing/cross-browser-testing/javascript/bad-for-loop.html
@@ -5,16 +5,15 @@
     <title>Bad for loop</title>
   </head>
   <body>
-
-  </body>
-  <script>
-    for(var i = 1; i <= 10; i++) {
-      var para = document.createElement('p');
-      para.textContent = 'This is paragraph ' + i + '.';
-      document.body.appendChild(para);
-      para.onclick = function() {
-        alert('Hello from paragraph ' + i + '!');
+    <script>
+      for(var i = 1; i <= 10; i++) {
+        var para = document.createElement('p');
+        para.textContent = 'This is paragraph ' + i + '.';
+        document.body.appendChild(para);
+        para.onclick = function() {
+          alert('Hello from paragraph ' + i + '!');
+        }
       }
-    }
-  </script>
+    </script>
+  </body>
 </html>

--- a/tools-testing/cross-browser-testing/javascript/fetch-polyfill-finished.html
+++ b/tools-testing/cross-browser-testing/javascript/fetch-polyfill-finished.html
@@ -17,18 +17,18 @@
     <h1>Fetch basic example</h1>
 
     <img src="" class="my-image" alt="A flower">
-  </body>
-  <script src="es6-promise.js"></script>
-  <script src="fetch.js"></script>
-  <script>
-    var myImage = document.querySelector('.my-image');
 
-    fetch('flowers.jpg').then(function(response) {
-      response.blob().then(function(myBlob) {
-        var objectURL = URL.createObjectURL(myBlob);
-        myImage.src = objectURL;
+    <script src="es6-promise.js"></script>
+    <script src="fetch.js"></script>
+    <script>
+      var myImage = document.querySelector('.my-image');
+
+      fetch('flowers.jpg').then(function(response) {
+        response.blob().then(function(myBlob) {
+          var objectURL = URL.createObjectURL(myBlob);
+          myImage.src = objectURL;
+        });
       });
-    });
-
-  </script>
+    </script>
+  </body>
 </html>

--- a/tools-testing/cross-browser-testing/javascript/fetch-polyfill-only-when-needed.html
+++ b/tools-testing/cross-browser-testing/javascript/fetch-polyfill-only-when-needed.html
@@ -17,39 +17,40 @@
     <h1>Fetch basic example</h1>
 
     <img src="" class="my-image" alt="A flower">
-  </body>
-  <script>
-    if (browserSupportsAllFeatures()) {
-      main();
-    } else {
-      loadScript('polyfills.js', main);
-    }
 
-    function main(err) {
-      var myImage = document.querySelector('.my-image');
+    <script>
+      if (browserSupportsAllFeatures()) {
+        main();
+      } else {
+        loadScript('polyfills.js', main);
+      }
 
-      fetch('flowers.jpg').then(function(response) {
-        response.blob().then(function(myBlob) {
-          var objectURL = URL.createObjectURL(myBlob);
-          myImage.src = objectURL;
+      function main(err) {
+        var myImage = document.querySelector('.my-image');
+
+        fetch('flowers.jpg').then(function(response) {
+          response.blob().then(function(myBlob) {
+            var objectURL = URL.createObjectURL(myBlob);
+            myImage.src = objectURL;
+          });
         });
-      });
-    }
+      }
 
-    function browserSupportsAllFeatures() {
-      return window.Promise && window.fetch;
-    }
+      function browserSupportsAllFeatures() {
+        return window.Promise && window.fetch;
+      }
 
-    function loadScript(src, done) {
-      var js = document.createElement('script');
-      js.src = src;
-      js.onload = function() {
-        done();
-      };
-      js.onerror = function() {
-        done(new Error('Failed to load script ' + src));
-      };
-      document.head.appendChild(js);
-    }
-  </script>
+      function loadScript(src, done) {
+        var js = document.createElement('script');
+        js.src = src;
+        js.onload = function() {
+          done();
+        };
+        js.onerror = function() {
+          done(new Error('Failed to load script ' + src));
+        };
+        document.head.appendChild(js);
+      }
+    </script>
+  </body>
 </html>

--- a/tools-testing/cross-browser-testing/javascript/good-for-loop.html
+++ b/tools-testing/cross-browser-testing/javascript/good-for-loop.html
@@ -5,20 +5,19 @@
     <title>Good for loop</title>
   </head>
   <body>
-
-  </body>
-  <script>
-    for(var i = 1; i <= 10; i++) {
-      var para = document.createElement('p');
-      para.textContent = 'This is paragraph ' + i + '.';
-      document.body.appendChild(para);
-      addHandler(para, i);
-    }
-
-    function addHandler(para, i) {
-      para.onclick = function() {
-        alert('Hello from paragraph ' + i + '!');
+    <script>
+      for(var i = 1; i <= 10; i++) {
+        var para = document.createElement('p');
+        para.textContent = 'This is paragraph ' + i + '.';
+        document.body.appendChild(para);
+        addHandler(para, i);
       }
-    }
-  </script>
+
+      function addHandler(para, i) {
+        para.onclick = function() {
+          alert('Hello from paragraph ' + i + '!');
+        }
+      }
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
According to [the article](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#Applying_CSS_and_JavaScript_to_HTML):

> The <script> element does not have to go in the head; in fact, often it is better to put it at the bottom of the document body (just _before_ the closing &lt;/body&gt; tag), to make sure that all the HTML content has been read by the browser before it tries to apply JavaScript to it (if JavaScript tries to access an element that doesn't yet exist, the browser will throw an error.)

Also, with the `<script>` after the closing `</body>` we'll not pass W3C validation:

<details>
  <summary>W3C validation result</summary>
  <img src="https://monosnap.com/file/uSR5PKwyYyWyXycXTXABcpy2yfuESn.png">
</details><br>

Not sure, can we safely move all `<script>` tags before the closing `</body>` in all other cases in the repo.