### PR TITLE
Update can-script.js

### DIFF
--- a/javascript/apis/fetching-data/can-store/can-script.js
+++ b/javascript/apis/fetching-data/can-store/can-script.js
@@ -128,7 +128,7 @@ function initialize() {
 
     // if no products match the search term, display a "No results to display" message
     if(finalGroup.length === 0) {
-      var para = document.querySelector('p');
+      var para = document.createElement('p');
       para.textContent = 'No results to display!';
       main.appendChild(para);
     // for each product we want to display, pass its product object to fetchBlob()


### PR DESCRIPTION
The first time after all the search is not satisfied, querySelector ('p') to find the element is the footer under the p element, added to the main element below, the second time after all search, p element has been removed , The page does not have a p element, and document.querySelector ('p') returns null