### PR TITLE
Match output of unchecking in CSS editor

### DIFF
--- a/css/introduction-to-css/debugging-css-finished/style.css
+++ b/css/introduction-to-css/debugging-css-finished/style.css
@@ -35,7 +35,7 @@ header, footer {
 }
 
 h1, footer p {
-  margin: 0;
+  /*! margin: -70px; */
 }
 
 h1 {


### PR DESCRIPTION
The [instructions](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Debugging_CSS#Active_learning_find_the_errors!) say to <q cite="https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Debugging_CSS#Active_learning_find_the_errors!">try clicking on the <code>&lt;h1&gt;</code> and unchecking the applied declarations to find out which one is causing the problem.</q> Unchecking an element in the CSS editor changes the element to a comment.