### PR TITLE
Remove redundant code from client-side storage examples

### DIFF
--- a/javascript/apis/client-side-storage/indexeddb/notes/index.js
+++ b/javascript/apis/client-side-storage/indexeddb/notes/index.js
@@ -126,9 +126,7 @@ window.onload = function() {
 
         // Set an event handler so that when the button is clicked, the deleteItem()
         // function is run
-        deleteBtn.onclick = function(e) {
-          deleteItem(e);
-        };
+        deleteBtn.onclick = deleteItem;
 
         // Iterate to the next item in the cursor
         cursor.continue();

--- a/javascript/apis/client-side-storage/indexeddb/video-store/index.js
+++ b/javascript/apis/client-side-storage/indexeddb/video-store/index.js
@@ -42,7 +42,7 @@ function init() {
     );
     let webmBlob = fetch('videos/' + video.name + '.webm').then(response =>
       response.blob()
-    );;
+    );
 
     // Only run the next code when both promises have fulfilled
     Promise.all([mp4Blob, webmBlob]).then(function(values) {


### PR DESCRIPTION
These also show up in code samples in [the article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage). I didn't make the changes there since I'm not sure what the policy is for updating excerpts from a repo.

This probably isn't the place, but since I've got your attention, I found
> until after all the tasks inside the block have been completed.

to be oddly worded. It had me thinking some kind of magic was taking place based on a code block until I actually looked at the example and the related [documentation](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil) to see it was just waiting on the promise to settle.

Thanks for all of your work!