### PR TITLE
can-store patches

### DIFF
--- a/javascript/apis/fetching-data/can-store/can-script.js
+++ b/javascript/apis/fetching-data/can-store/can-script.js
@@ -25,7 +25,8 @@ function initialize() {
 
   // keep a record of what the last category and search term entered were
   var lastCategory = category.value;
-  var lastSearch = searchTerm.value;
+  // no search has been made yet
+  var lastSearch = '';
 
   // these contain the results of filtering by category, and search term
   // finalGroup will contain the products that need to be displayed after

--- a/javascript/apis/fetching-data/can-store/can-script.js
+++ b/javascript/apis/fetching-data/can-store/can-script.js
@@ -60,12 +60,12 @@ function initialize() {
     // if the category and search term are the same as they were the last time a
     // search was run, the results will be the same, so there is no point running
     // it again — just return out of the function
-    if(category.value === lastCategory && searchTerm.value === lastSearch) {
+    if(category.value === lastCategory && searchTerm.value.trim() === lastSearch) {
       return;
     } else {
       // update the record of last category and search term
       lastCategory = category.value;
-      lastSearch = searchTerm.value;
+      lastSearch = searchTerm.value.trim();
       // In this case we want to select all products, then filter them by the search
       // term, so we just set categoryGroup to the entire JSON object, then run selectProducts()
       if(category.value === 'All') {
@@ -98,13 +98,13 @@ function initialize() {
   function selectProducts() {
     // If no search term has been entered, just make the finalGroup array equal to the categoryGroup
     // array — we don't want to filter the products further — then run updateDisplay().
-    if(searchTerm.value === '') {
+    if(searchTerm.value.trim() === '') {
       finalGroup = categoryGroup;
       updateDisplay();
     } else {
       // Make sure the search term is converted to lower case before comparison. We've kept the
       // product names all lower case to keep things simple
-      var lowerCaseSearchTerm = searchTerm.value.toLowerCase();
+      var lowerCaseSearchTerm = searchTerm.value.trim().toLowerCase();
       // For each product in categoryGroup, see if the search term is contained inside the product name
       // (if the indexOf() result doesn't return -1, it means it is) — if it is, then push the product
       // onto the finalGroup array


### PR DESCRIPTION
Two small fixes that I made:

1.  **Issue:** If you write something in the search box, then reload the page, what you wrote before remains (there's no problem there) but if you click the filter button without modifying the already existing search query, it won't filter anything and will show all the products.<br/>
 **Fix:** The problem happens because, after reloading, `lastSearch` takes the value of `searchTerm` (which is not empty), satisfies the condition checked in line 63 and stops the function before any filtering. The fix is easy, you just need to initialize `lastSearch` with an empty string; because when page loads, no search has been made yet.

2.  **Issue:** Trailing/leading whitespaces in search queries are taking into consideration, and I think they should be removed in case the user typed them by mistake.  <br/>
**Fix:** To trim the value of lastSearch when it's taking into consideration in the code.