### PR TITLE
nytimes patches

### DIFF
--- a/javascript/apis/third-party-apis/nytimes/index.html
+++ b/javascript/apis/third-party-apis/nytimes/index.html
@@ -72,10 +72,14 @@
       var displayNav = false;
 
       // Event listeners to control the functionality
-      searchForm.addEventListener('submit', fetchResults);
+      searchForm.addEventListener('submit', submitSearch);
       nextBtn.addEventListener('click', nextPage);
       previousBtn.addEventListener('click', previousPage);
-
+      
+      function submitSearch(e){
+        pageNumber = 0;
+        fetchResults(e);
+      }
 
       function fetchResults(e) {
         // Use preventDefault() to stop the form submitting

--- a/javascript/apis/third-party-apis/nytimes/index.html
+++ b/javascript/apis/third-party-apis/nytimes/index.html
@@ -140,7 +140,7 @@
             para2.textContent = 'Keywords: ';
             for(var j = 0; j < current.keywords.length; j++) {
               var span = document.createElement('span');
-              span.textContent += current.keywords[j].value + ' ';
+              span.textContent = current.keywords[j].value + ' ';
               para2.appendChild(span);
             }
 

--- a/javascript/apis/third-party-apis/nytimes/index.html
+++ b/javascript/apis/third-party-apis/nytimes/index.html
@@ -132,7 +132,7 @@
 
             link.href = current.web_url;
             link.textContent = current.headline.main;
-            para1.textContent = current.lead_paragraph;
+            para1.textContent = current.snippet;
             para2.textContent = 'Keywords: ';
             for(var j = 0; j < current.keywords.length; j++) {
               var span = document.createElement('span');

--- a/javascript/apis/third-party-apis/nytimes/index.html
+++ b/javascript/apis/third-party-apis/nytimes/index.html
@@ -82,7 +82,7 @@
         e.preventDefault();
 
         // Assemble the full URL
-        url = baseURL + '?api-key=' + key + '&page=' + pageNumber + '&q=' + searchTerm.value;
+        url = baseURL + '?api-key=' + key + '&page=' + pageNumber + '&q=' + searchTerm.value + '&fq=document_type:("article")';
 
         if(startDate.value !== '') {
           url += '&begin_date=' + startDate.value;


### PR DESCRIPTION
Fixes I made:

1. **Issue:**  `current.lead_paragraph` returns 'undefined' and makes that every article shows no brief description of it; in fact such property is not listed in the object but it's still listed in the api documentation.<br/>
**Solution:**  `snippet` is property that gives a similar desired result, so I used that instead.

2. **Issue:** If we use queries like 'cats' or 'recipes' and leaving start-date/end-date empty, we end up with a  bunch of articles at the top of our search that are not real articles but 'topics' with broken links.<br/>
**Solution:** Filter search to items with 'article' as the value of  `document_type`, as explained [here](https://developer.nytimes.com/article_search_v2.json#/README#filtering-your-search).

3. **Issue:** `pageNumber` never resets which makes that every new search starts from the same page number that a previous search reached.<br/>
**Solution:** Implement a function similar to `nextPage`/`previousPage`, that will reset `pageNumber` every time a new search is made.

4. Well, this one was a very small code typo; there was `span.textContent += current.keywords[j].value + ' ';` but span is created at every `for` loop, so there's no previous value of it and there's no need of an addition assignment, a simple assignment will work exactly the same.
