### PR TITLE
Reference correct video source video file

### DIFF
--- a/javascript/apis/video-audio/finished/index.html
+++ b/javascript/apis/video-audio/finished/index.html
@@ -9,7 +9,7 @@
       <div class="player">
         <video controls>
           <source src="video/sintel-short.mp4" type="video/mp4">
-          <source src="video/sintel-short.mp4" type="video/webm">
+          <source src="video/sintel-short.webm" type="video/webm">
           <!-- fallback content here -->
         </video>
         <div class="controls">

--- a/javascript/apis/video-audio/start/index.html
+++ b/javascript/apis/video-audio/start/index.html
@@ -9,7 +9,7 @@
     <div class="player">
       <video controls>
         <source src="video/sintel-short.mp4" type="video/mp4">
-        <source src="video/sintel-short.mp4" type="video/webm">
+        <source src="video/sintel-short.webm" type="video/webm">
         <!-- fallback content here -->
       </video>
       <div class="controls">


### PR DESCRIPTION
In the video and audio APIs tutorial the second source file references the `.mp4` file, but it should reference the `.webm` file.