### PR TITLE
<html> element must have a lang attribute

### DIFF
--- a/accessibility/aria/aria-div-buttons.html
+++ b/accessibility/aria/aria-div-buttons.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>ARIA div buttons</title>

--- a/accessibility/aria/aria-div-buttons.html
+++ b/accessibility/aria/aria-div-buttons.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>ARIA div buttons</title>

--- a/accessibility/aria/aria-live.html
+++ b/accessibility/aria/aria-live.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/aria-live.html
+++ b/accessibility/aria/aria-live.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/aria-no-live.html
+++ b/accessibility/aria/aria-no-live.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/aria-no-live.html
+++ b/accessibility/aria/aria-no-live.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/aria-tabbed-info-box.html
+++ b/accessibility/aria/aria-tabbed-info-box.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>ARIA tabbed info box</title>

--- a/accessibility/aria/aria-tabbed-info-box.html
+++ b/accessibility/aria/aria-tabbed-info-box.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <title>ARIA tabbed info box</title>

--- a/accessibility/aria/form-validation-checkbox-disabled.html
+++ b/accessibility/aria/form-validation-checkbox-disabled.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/aria/form-validation-checkbox-disabled.html
+++ b/accessibility/aria/form-validation-checkbox-disabled.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/aria/form-validation-updated.html
+++ b/accessibility/aria/form-validation-updated.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/aria/form-validation-updated.html
+++ b/accessibility/aria/form-validation-updated.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/aria/website-aria-roles/index.html
+++ b/accessibility/aria/website-aria-roles/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/website-aria-roles/index.html
+++ b/accessibility/aria/website-aria-roles/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/website-no-roles/index.html
+++ b/accessibility/aria/website-no-roles/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/aria/website-no-roles/index.html
+++ b/accessibility/aria/website-no-roles/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-finished/index.html
+++ b/accessibility/assessment-finished/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-finished/index.html
+++ b/accessibility/assessment-finished/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-finished/transcript.html
+++ b/accessibility/assessment-finished/transcript.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-finished/transcript.html
+++ b/accessibility/assessment-finished/transcript.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-start/index.html
+++ b/accessibility/assessment-start/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/assessment-start/index.html
+++ b/accessibility/assessment-start/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/css/form-css.html
+++ b/accessibility/css/form-css.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Form CSS example</title>

--- a/accessibility/css/form-css.html
+++ b/accessibility/css/form-css.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Form CSS example</title>

--- a/accessibility/css/form-validation.html
+++ b/accessibility/css/form-validation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/css/form-validation.html
+++ b/accessibility/css/form-validation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Form validation example</title>

--- a/accessibility/css/mouse-and-keyboard-events.html
+++ b/accessibility/css/mouse-and-keyboard-events.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Mouse and keyboard events example</title>

--- a/accessibility/css/mouse-and-keyboard-events.html
+++ b/accessibility/css/mouse-and-keyboard-events.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Mouse and keyboard events example</title>

--- a/accessibility/css/table-css.html
+++ b/accessibility/css/table-css.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Table CSS example</title>

--- a/accessibility/css/table-css.html
+++ b/accessibility/css/table-css.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Table CSS example</title>

--- a/accessibility/html/accessible-image.html
+++ b/accessibility/html/accessible-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Accessible image example</title>

--- a/accessibility/html/accessible-image.html
+++ b/accessibility/html/accessible-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Accessible image example</title>

--- a/accessibility/html/bad-form.html
+++ b/accessibility/html/bad-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Bad form example</title>

--- a/accessibility/html/bad-form.html
+++ b/accessibility/html/bad-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Bad form example</title>

--- a/accessibility/html/bad-links.html
+++ b/accessibility/html/bad-links.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Bad links example</title>

--- a/accessibility/html/bad-links.html
+++ b/accessibility/html/bad-links.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Bad links example</title>

--- a/accessibility/html/bad-semantics.html
+++ b/accessibility/html/bad-semantics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Bad semantics example</title>

--- a/accessibility/html/bad-semantics.html
+++ b/accessibility/html/bad-semantics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Bad semantics example</title>

--- a/accessibility/html/bad-table.html
+++ b/accessibility/html/bad-table.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Bad table example</title>

--- a/accessibility/html/bad-table.html
+++ b/accessibility/html/bad-table.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Bad table example</title>

--- a/accessibility/html/dino-info.html
+++ b/accessibility/html/dino-info.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Dinosaur longdesc</title>

--- a/accessibility/html/dino-info.html
+++ b/accessibility/html/dino-info.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Dinosaur longdesc</title>

--- a/accessibility/html/good-form.html
+++ b/accessibility/html/good-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Good form example</title>

--- a/accessibility/html/good-form.html
+++ b/accessibility/html/good-form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Good form example</title>

--- a/accessibility/html/good-links.html
+++ b/accessibility/html/good-links.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Good links example</title>

--- a/accessibility/html/good-links.html
+++ b/accessibility/html/good-links.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Good links example</title>

--- a/accessibility/html/good-semantics.html
+++ b/accessibility/html/good-semantics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Good semantics example</title>

--- a/accessibility/html/good-semantics.html
+++ b/accessibility/html/good-semantics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Good semantics example</title>

--- a/accessibility/html/native-keyboard-accessibility.html
+++ b/accessibility/html/native-keyboard-accessibility.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Native keyboard accessibility</title>

--- a/accessibility/html/native-keyboard-accessibility.html
+++ b/accessibility/html/native-keyboard-accessibility.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Native keyboard accessibility</title>

--- a/accessibility/html/table-layout.html
+++ b/accessibility/html/table-layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/html/table-layout.html
+++ b/accessibility/html/table-layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
 

--- a/accessibility/mobile/common-job-types.html
+++ b/accessibility/mobile/common-job-types.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Common job types example</title>

--- a/accessibility/mobile/common-job-types.html
+++ b/accessibility/mobile/common-job-types.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Common job types example</title>

--- a/accessibility/mobile/html5-form-examples.html
+++ b/accessibility/mobile/html5-form-examples.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>HTML5 form examples</title>

--- a/accessibility/mobile/html5-form-examples.html
+++ b/accessibility/mobile/html5-form-examples.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>HTML5 form examples</title>

--- a/accessibility/mobile/multi-control-box-drag.html
+++ b/accessibility/mobile/multi-control-box-drag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">

--- a/accessibility/mobile/multi-control-box-drag.html
+++ b/accessibility/mobile/multi-control-box-drag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">

--- a/accessibility/mobile/simple-box-drag.html
+++ b/accessibility/mobile/simple-box-drag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Simple box drag example</title>

--- a/accessibility/mobile/simple-box-drag.html
+++ b/accessibility/mobile/simple-box-drag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Simple box drag example</title>

--- a/accessibility/mobile/simple-button-example.html
+++ b/accessibility/mobile/simple-button-example.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Simple button example</title>

--- a/accessibility/mobile/simple-button-example.html
+++ b/accessibility/mobile/simple-button-example.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Simple button example</title>

--- a/accessibility/multimedia/audio-transcript-ui/index.html
+++ b/accessibility/multimedia/audio-transcript-ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Audio transcript example</title>

--- a/accessibility/multimedia/audio-transcript-ui/index.html
+++ b/accessibility/multimedia/audio-transcript-ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Audio transcript example</title>

--- a/accessibility/multimedia/custom-controls-OOJS/index.html
+++ b/accessibility/multimedia/custom-controls-OOJS/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Multiple media players with custom controls</title>

--- a/accessibility/multimedia/custom-controls-basic/index.html
+++ b/accessibility/multimedia/custom-controls-basic/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Basic custom controls</title>

--- a/accessibility/multimedia/custom-controls-start.html
+++ b/accessibility/multimedia/custom-controls-start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Basic custom controls</title>

--- a/accessibility/multimedia/native-controls.html
+++ b/accessibility/multimedia/native-controls.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Multiple media players with native controls</title>


### PR DESCRIPTION
When configuring a screen reader, users select a default language. If the language of a webpage is not specified, the screen reader will assume it is the default language set by the user. This becomes an issue for users who speak multiple languages and access website in more than one language. It is important to specify a language and ensure that it is valid so website text is pronounced correctly.

For example, my VoiceOver is trying to read these links in Russian
[Screenreader testing](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreader_testing) section
> Look at [good-semantics.html](http://mdn.github.io/learning-area/accessibility/html/good-semantics.html), and note how the headers are found by the screenreader and available to use for navigation. Now look at [bad-semantics.html](http://mdn.github.io/learning-area/accessibility/html/bad-semantics.html), and note how the screenreader gets none of this information. Imagine how annoying this would be when trying to navigate a really long page of text.