### PR TITLE
Populate balls array outside the animation loop

### DIFF
--- a/javascript/oojs/bouncing-balls/main-finished.js
+++ b/javascript/oojs/bouncing-balls/main-finished.js
@@ -72,30 +72,30 @@ Ball.prototype.collisionDetect = function() {
   }
 };
 
-// define array to store balls
+// define array to store balls and populate it
 
 var balls = [];
+
+while(balls.length < 25) {
+  var size = random(10,20);
+  var ball = new Ball(
+    // ball position always drawn at least one ball width
+    // away from the adge of the canvas, to avoid drawing errors
+    random(0 + size,width - size),
+    random(0 + size,height - size),
+    random(-7,7),
+    random(-7,7),
+    'rgb(' + random(0,255) + ',' + random(0,255) + ',' + random(0,255) +')',
+    size
+  );
+  balls.push(ball);
+}
 
 // define loop that keeps drawing the scene constantly
 
 function loop() {
   ctx.fillStyle = 'rgba(0,0,0,0.25)';
   ctx.fillRect(0,0,width,height);
-
-  while(balls.length < 25) {
-    var size = random(10,20);
-    var ball = new Ball(
-      // ball position always drawn at least one ball width
-      // away from the adge of the canvas, to avoid drawing errors
-      random(0 + size,width - size),
-      random(0 + size,height - size),
-      random(-7,7),
-      random(-7,7),
-      'rgb(' + random(0,255) + ',' + random(0,255) + ',' + random(0,255) +')',
-      size
-    );
-    balls.push(ball);
-  }
 
   for(var i = 0; i < balls.length; i++) {
     balls[i].draw();


### PR DESCRIPTION
In the bouncing balls javascript example, the array to store object is populated inside the animation loop. This doesn't seem necessary since no ball is lost.

To keep things a bit cleaner, we can populate it outside the animation loop.

As far as I can tell, this would also require changes [here](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_building_practice#Animating_the_ball) and a similar [here](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Drawing_graphics#Animations).