### PR TITLE
add es6 version of main-finished.js

### DIFF
--- a/javascript/oojs/bouncing-balls/main-finished-es6.js
+++ b/javascript/oojs/bouncing-balls/main-finished-es6.js
@@ -1,0 +1,109 @@
+// setup canvas
+
+var canvas = document.querySelector('canvas');
+var ctx = canvas.getContext('2d');
+
+var width = canvas.width = window.innerWidth;
+var height = canvas.height = window.innerHeight;
+
+// function to generate random number
+
+function random(min,max) {
+   var num = Math.floor(Math.random()*(max-min)) + min;
+   return num;
+}
+
+var canvas = document.querySelector('canvas');
+
+var ctx = canvas.getContext('2d');
+
+var width = canvas.width = window.innerWidth;
+var height = canvas.height = window.innerHeight;
+
+class Ball {
+   
+   constructor(x, y, velX, velY, color, size) {
+      this.x = x;
+      this.y = y;
+      this.velX = velX;
+      this.velY = velY;
+      this.color = color;
+      this.size = size;
+   }
+   
+   draw() {
+      ctx.beginPath();
+      ctx.fillStyle = this.color;
+      ctx.arc(this.x, this.y, this.size, 0, 2 * Math.PI);
+      ctx.fill();
+   }
+   
+   update() {      
+      if ((this.x + this.size) >= width) {
+         this.velX = -(this.velX);
+      }
+
+      if ((this.x - this.size) <= 0) {
+         this.velX = -(this.velX);
+      }
+
+      if ((this.y + this.size) >= height) {
+         this.velY = -(this.velY);
+      }
+
+      if ((this.y - this.size) <= 0) {
+         this.velY = -(this.velY);
+      }
+
+      this.x += this.velX;
+      this.y += this.velY;      
+   }
+   
+   collisionDetect() {     
+      for (var j = 0; j < balls.length; j++) {
+         if (!(this === balls[j])) {
+            var dx = this.x - balls[j].x;
+            var dy = this.y - balls[j].y;
+            var distance = Math.sqrt(dx * dx + dy * dy);
+
+            if (distance < this.size + balls[j].size) {
+              balls[j].color = this.color = 'rgb(' + random(0, 255) + ',' + random(0, 255) + ',' + random(0, 255) +')';
+            }
+         }
+      }
+   }
+   
+}
+
+var balls = [];
+
+while (balls.length < 25) {
+   var size = random(10,20);
+   var ball = new Ball(
+      // ball position always drawn at least one ball width
+      // away from the edge of the canvas, to avoid drawing errors
+      random(0 + size,width - size),
+      random(0 + size,height - size),
+      random(-7,7),
+      random(-7,7),
+      'rgb(' + random(0,255) + ',' + random(0,255) + ',' + random(0,255) +')',
+      size
+   );
+
+  balls.push(ball);
+}
+
+function loop() {
+   ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
+   ctx.fillRect(0, 0, width, height);
+
+   for (var i = 0; i < balls.length; i++) {
+     balls[i].draw();
+     balls[i].update();
+     balls[i].collisionDetect();
+   }
+
+   requestAnimationFrame(loop);
+}
+
+loop();


### PR DESCRIPTION
example ES6 version of the complete bouncing ball practice. 

In the object building practice article there is a guide to create a bounding balls animation demo. For educational reasons it is good to write ES5 style inheritance, but by now due to the wide ES6 support of browsers I think it makes more sense to at least link this file (if not replace the original one) in the tutorial. 