### PR TITLE
use Object.defineProperty as in tutorial docs

### DIFF
--- a/javascript/oojs/advanced/oojs-class-inheritance-finished.html
+++ b/javascript/oojs/advanced/oojs-class-inheritance-finished.html
@@ -97,7 +97,11 @@
       }
 
       Teacher.prototype = Object.create(Person.prototype);
-      Teacher.prototype.constructor = Teacher;
+      Object.defineProperty(Teacher.prototype, 'constructor', { 
+         value: Teacher, 
+         enumerable: false, // so that it does not appear in 'for in' loop
+         writable: true 
+      });
 
       Teacher.prototype.greeting = function() {
         var prefix;


### PR DESCRIPTION
In tutorial docs:
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Inheritance#Setting_Teacher()'s_prototype_and_constructor_reference

Here you redefine Teacher.prototype.constructor with Object.defineProperty, but in  in this code you use the simply use the equals operator. I propose to update this file or the tutorial guidelines.