### PR TITLE
declare once, keeping it value in range [0;360)

### DIFF
--- a/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html
+++ b/javascript/asynchronous/loops-and-intervals/simple-raf-spinner.html
@@ -42,15 +42,16 @@
          startTime = timestamp;
         }
 
-        let rotateCount = (timestamp - startTime) / 3;
+        rotateCount = (timestamp - startTime) / 3;
+        
+        // If rotateCount gets over 359, set it to 'remainder of dividing by 360'
+        if(rotateCount > 359) {
+          rotateCount %= 360;
+        }
 
         // Set the rotation of the div to be equal to rotateCount degrees
         spinner.style.transform = 'rotate(' + rotateCount + 'deg)';
-
-        // If rotateCount gets to 360, set it back to 0, set it back to 0
-        if(rotateCount > 359) {
-          rotateCount -= 360;
-        }
+       
         // Call the next frame in the animation
         rAF = requestAnimationFrame(draw);
       }


### PR DESCRIPTION
Problems in original code:
1) Original statement:
> if (rotateCount > 359) {
>   rotateCount -= 360;
> }

doesn't keep value in range [0;360), because 'timestamp' grow endless,  startTime doesn't change after first assigned value,  the value of rotateCount can be thousands,  removing 360 from the value don't help...

2.  rotateCount first used 
> spinner.style.transform = 'rotate(' + rotateCount + 'deg)';

then changed by statement (1), then doesn't used (value) on iteration.

3. Twice declarations of variables with the same name 'rotateCount': in Global scope and in functional scope.

Solutions:
1. calculating remainder (of dividing) if needed.
2. placing 'if' statement 
'if(rotateCount > 359) { rotateCount %= 360;}'
just  after first calculation value of rotateCount.
3. removing keyword 'let' before rotateCount inside function  ('rotateCount = (timestamp - startTime) / 3;').

@chrisdavidmills 