### PR TITLE
Dealing with reset button's issue.

### DIFF
--- a/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html
+++ b/javascript/asynchronous/loops-and-intervals/setinterval-stopwatch.html
@@ -58,6 +58,8 @@
 
       // When the reset button is pressed, set the counter back to zero, then immediately update the display
       resetBtn.addEventListener('click', () => {
+        clearInterval(stopWatch);
+        startBtn.disabled = false;
         secondCount = 0;
         displayCount();
       });


### PR DESCRIPTION
Letting users to use the reset button straight after they press the start button without the clock having wrong behavior. Originally, if a user starts the clock and doesn't press the stop button before pressing the reset button, the clock will reset to 00:00:00 and then start running again automatically.