### PR TITLE
Using srcObject instead of createObjectURL

### DIFF
--- a/javascript/apis/drawing-graphics/threejs-video-cube/scripts/main.js
+++ b/javascript/apis/drawing-graphics/threejs-video-cube/scripts/main.js
@@ -18,9 +18,8 @@ if (navigator.getUserMedia) {
 
       // Success callback
       function(stream) {
-        var videoURL = window.URL.createObjectURL(stream);
         var video = document.createElement('video');
-        video.src = videoURL;
+        video.srcObject = stream;
         video.onloadedmetadata = function() {
           video.play();
           threeRender(video);


### PR DESCRIPTION
createObjectURL no longer accepts MediaStreams, so the previous version threw a TypeError.