### PR TITLE
Update the info box color and margins to match the capture.

### DIFF
--- a/css/css-layout/practical-positioning-examples/info-box.html
+++ b/css/css-layout/practical-positioning-examples/info-box.html
@@ -22,16 +22,19 @@
   /* info-box setup */
 
   .info-box {
-    width: 450px;
+    width: 452px;
     height: 400px;
-    margin: 0 auto;
+    margin: 20px auto 0;
   }
 
   /* styling info-box tabs */
 
   .info-box ul {
-    padding-left: 0;
-    margin-top: 0;
+    border: 1px solid #b60000;
+    overflow: hidden;
+    height: 50px;
+    margin: 0;
+    padding: 0;
   }
 
   .info-box li {
@@ -44,19 +47,20 @@
     display: inline-block;
     text-decoration: none;
     width: 100%;
-    line-height: 3;
-    background-color: red;
-    color: black;
+    line-height: 50px;
+    background: white;
+    color: #b60000;
     text-align: center;
+    font-weight: bold;
   }
 
   .info-box li a:focus, .info-box li a:hover {
-    background-color: #a60000;
+    background-color: #b60000;
     color: white;
   }
 
   .info-box li a.active {
-    background-color: #a60000;
+    background-color: #b60000;
     color: white;
   }
 
@@ -69,10 +73,10 @@
   }
 
   .info-box article {
-    background-color: #a60000;
+    background-color: #b60000;
     color: white;
     position: absolute;
-    padding: 10px;
+    padding: 10px 20px;
     height: 352px;
     top: 0;
     left: 0;


### PR DESCRIPTION
@chrisdavidmills 

It seems that the capture has been replaced in https://github.com/mdn/sprints/issues/2307, so I tried adjusting the example so that it looks closer.

Can you adopt this?