### PR TITLE
Fallback example fix for Internet Explorer

### DIFF
--- a/html/forms/datetime-local-picker-fallback/index.html
+++ b/html/forms/datetime-local-picker-fallback/index.html
@@ -92,7 +92,13 @@ fallbackLabel.style.display = 'none';
 
 // test whether a new date input falls back to a text input or not
 var test = document.createElement('input');
-test.type = 'date';
+
+try {
+  test.type = 'time';
+} catch (e) {
+  console.log(e.description);
+}
+    
 // if it does, run the code inside the if() {} block
 if(test.type === 'text') {
   // hide the native picker and show the fallback


### PR DESCRIPTION
The intention of this example seems to be to illustrate how the fallback is enabled in browsers that don't support input type="time". The statement test.type = 'time'; fails in Internet Explorer 11, the obvious example of a browser that doesn't support type="time". I've changed the example so that it works in the Internet Explorer.