### PR TITLE
gender neutral / tel for credit card

### DIFF
--- a/html/forms/html-form-structure/payment-form.html
+++ b/html/forms/html-form-structure/payment-form.html
@@ -17,15 +17,21 @@
               <legend>Title</legend>
               <ul>
                   <li>
+                    <label for="title_2">
+                      <input type="radio" id="title_2" name="title" value="A">
+                      Ace
+                    </label>
+                  </li>
+                  <li>
                     <label for="title_1">
-                      <input type="radio" id="title_1" name="title" value="M." >
-                      Mister
+                      <input type="radio" id="title_1" name="title" value="K" >
+                      King
                     </label>
                   </li>
                   <li>
                     <label for="title_2">
-                      <input type="radio" id="title_2" name="title" value="Ms.">
-                      Miss
+                      <input type="radio" id="title_2" name="title" value="Q">
+                      Queen
                     </label>
                   </li>
               </ul>
@@ -69,7 +75,7 @@
                 <span>Card number:</span>
                 <strong><abbr title="required">*</abbr></strong>
               </label>
-                <input type="number" id="number" name="cardnumber">
+                <input type="tel" id="number" name="cardnumber">
             </p>
             <p>
               <label for="date">


### PR DESCRIPTION
Removed Miss and Mister and made it ace, king, queen to make it less gendered.
Changed credit card to tel instead of number, since a spinner is not correct for a cc#