### PR TITLE
changed alignment of cells

### DIFF
--- a/html/tables/basic/minimal-table-fix.css
+++ b/html/tables/basic/minimal-table-fix.css
@@ -1,0 +1,69 @@
+html {
+
+  font-family: sans-serif;
+
+}
+
+
+
+table {
+
+  border-collapse: collapse;
+
+  border: 2px solid rgb(200,200,200);
+
+  letter-spacing: 1px;
+
+  font-size: 0.8rem;
+
+}
+
+
+
+td, th {
+
+  border: 1px solid rgb(190,190,190);
+
+  padding: 10px 20px;
+
+}
+
+
+
+th {
+
+  background-color: rgb(235,235,235);
+
+}
+
+/***new: added th the following td selector and changed alignment to left (it was center)**/
+
+td,th {
+
+  text-align: left;
+
+}
+
+
+
+tr:nth-child(even) td {
+
+  background-color: rgb(250,250,250);
+
+}
+
+
+
+tr:nth-child(odd) td {
+
+  background-color: rgb(245,245,245);
+
+}
+
+
+
+caption {
+
+  padding: 10px;
+
+}


### PR DESCRIPTION
The issue said some things were not lining up (space to the left of some words)
This was because text align was center and some words were shorter so they were offset by center
I added th to the td selector in the css file and aligned all th and td cells to left