### PR TITLE
.innerHTML hint

### DIFF
--- a/javascript/building-blocks/tasks/loops/loops1-download.html
+++ b/javascript/building-blocks/tasks/loops/loops1-download.html
@@ -30,6 +30,8 @@
     let list = document.createElement('ul');
 
     // Add your code here
+    
+    // list strings should include > list.innerHTML
 
     // Don't edit the code below here!
 


### PR DESCRIPTION
When writing a line that contain "list", it transforms it to a String instead of a Node, so when .appendChild appears it throws this error in console:

**// Error: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'** 

My solution was:
 
   ```
 // Add your code here

let i = 0

while (i < myArray.length) {
    list.innerHTML += "<li>" + myArray[i] + "</li>";

    i++;
    
}

list.innerHTML += "</ul>";

    // Don't edit the code below here!
```