### PR TITLE
Make catch() called if URL is misspelled, as mentionned in tutorial

### DIFF
--- a/javascript/asynchronous/promises/simple-fetch.html
+++ b/javascript/asynchronous/promises/simple-fetch.html
@@ -11,7 +11,16 @@
 
       // Use a then() block to respond to the promise's successful completion
       // by taking the returned response and running blob() on it to transform it into a blob
-      let promise2 = promise.then(response => response.blob());
+      let promise2 = promise.then(response => {
+        // The promise fetch() does NOT reject on HTTP errors,
+        // so we need to check the boolean Response.ok and throw manually a new Error()
+        // for the promise2 to be rejected (for example when a 404 occurs).
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        } else {
+          return response.blob();
+        }
+      });
 
       // blob() also returns a promise; when it successfully completes it returns
       // The blob object in the callback


### PR DESCRIPTION
Fix to call catch() method when a HTTP error occurs. 
For example when the URL trying to be fetched has been misspelling, as mentionned on the tutorial here : 
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#Responding_to_failure

Otherwise the catch() method is never called, and the tutorial does not work at this point.