### PR TITLE
Change variable ‘spinner’ value to ‘true’

### DIFF
--- a/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html
+++ b/javascript/asynchronous/loops-and-intervals/start-and-stop-spinner.html
@@ -37,7 +37,7 @@
       let startTime = null;
 
       // Boolean variable to store state of spinner — true is spinning, false is not spinning
-      let spinning = false;
+      let spinning = true;
 
       // Create a draw() function
       function draw(timestamp) {
@@ -70,6 +70,8 @@
           spinning = true;
         }
       });
+
+draw();
     </script>
   </body>
 </html>


### PR DESCRIPTION
The pause and continue action of the icon won’t work, if the variable is set to ‘false’. Also, added ‘draw()’ at the bottom to initialise the function.