### PR TITLE
Refactor IF condition to make it more simple

### DIFF
--- a/javascript/apis/third-party-apis/nytimes/index.html
+++ b/javascript/apis/third-party-apis/nytimes/index.html
@@ -176,10 +176,8 @@
   function previousPage(e) {
     if(pageNumber > 0) {
       pageNumber--;
-    } else {
-      return;
+      fetchResults(e);
     }
-    fetchResults(e);
   };
 
   </script>


### PR DESCRIPTION
It seems to me that we do not need to use a "else" condition and force a return.