### PR TITLE
Bring bouncing balls JS in line with tutorial text

### DIFF
--- a/javascript/oojs/bouncing-balls/main.js
+++ b/javascript/oojs/bouncing-balls/main.js
@@ -8,7 +8,7 @@ const height = canvas.height = window.innerHeight;
 
 // function to generate random number
 
-function random(min,max) {
-  const num = Math.floor(Math.random()*(max-min)) + min;
+function random(min, max) {
+  const num = Math.floor(Math.random() * (max - min + 1)) + min;
   return num;
 }


### PR DESCRIPTION
On https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_building_practice, the random function generates a number in [min, max], whereas in the provided main.js file it is [min, max).