### PR TITLE
Update 6_fixed-positioning.html

### DIFF
--- a/css/css-layout/positioning/6_fixed-positioning.html
+++ b/css/css-layout/positioning/6_fixed-positioning.html
@@ -8,7 +8,7 @@
       body {
         width: 500px;
         height: 1400px;
-        margin: 0 auto
+        margin: 0 auto;
       }
 
       p {

--- a/css/css-layout/positioning/6_fixed-positioning.html
+++ b/css/css-layout/positioning/6_fixed-positioning.html
@@ -8,7 +8,7 @@
       body {
         width: 500px;
         height: 1400px;
-        margin: 0 auto;
+        margin-top: 0;
       }
 
       p {

--- a/css/css-layout/positioning/6_fixed-positioning.html
+++ b/css/css-layout/positioning/6_fixed-positioning.html
@@ -8,7 +8,7 @@
       body {
         width: 500px;
         height: 1400px;
-        margin-top: 0;
+        margin: 0 auto
       }
 
       p {
@@ -27,6 +27,7 @@
         position: fixed;
         top: 0px;
         width: 500px;
+        margin-top: 0;
         background: white;
         padding: 10px;
       }

--- a/css/css-layout/positioning/6_fixed-positioning.html
+++ b/css/css-layout/positioning/6_fixed-positioning.html
@@ -27,7 +27,6 @@
         position: fixed;
         top: 0px;
         width: 500px;
-        margin: 0 auto;
         background: white;
         padding: 10px;
       }


### PR DESCRIPTION
centering an element using `margin: 0 auto;` doesn't work without the explicit `left: 0` and `right: 0` combination (in case we want to center the element within the full viewport width)