### PR TITLE
events2 exercise: Without tabIndex the canvas can't get focus

### DIFF
--- a/javascript/building-blocks/tasks/events/events2-download.html
+++ b/javascript/building-blocks/tasks/events/events2-download.html
@@ -25,7 +25,7 @@
     <section class="preview">
     </section>
 
-    <canvas width="480" height="320">
+    <canvas width="480" height="320" tabindex="0">
 
     </canvas>
 

--- a/javascript/building-blocks/tasks/events/events2.html
+++ b/javascript/building-blocks/tasks/events/events2.html
@@ -30,7 +30,7 @@
 
     </section>
 
-    <canvas width="480" height="320">
+    <canvas width="480" height="320" tabindex="0">
 
     </canvas>
 


### PR DESCRIPTION
Without tabIndex the canvas can't get focus and the exercise won't work, without adding exactly this within the HTML area which is  above `// add your code here`