### PR TITLE
Add language to html tag and encode "|" in the URL"

### DIFF
--- a/html/introduction-to-html/structuring-a-page-of-content-start/index.html
+++ b/html/introduction-to-html/structuring-a-page-of-content-start/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Birdwatching</title>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300|Cinzel+Decorative:700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300%7CCinzel+Decorative:700" rel="stylesheet">
 
     <!--[if lt IE 9]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>


### PR DESCRIPTION
Using [W3c Nu HTML validator](https://validator.w3.org/nu/) The following errors appears:

1. Warning: Consider adding a lang attribute to the html start tag to declare the language of this document.
2. Error: Bad value https://fonts.googleapis.com/css?family=Roboto+Condensed:300|Cinzel+Decorative:700 for attribute href on element link: Illegal character in query: | is not allowed.
This PR fixes those.