### PR TITLE
End the game on "a" or "l" only

### DIFF
--- a/javascript/asynchronous/loops-and-intervals/reaction-game.html
+++ b/javascript/asynchronous/loops-and-intervals/reaction-game.html
@@ -202,15 +202,21 @@
         document.addEventListener('keydown', keyHandler);
 
         function keyHandler(e) {
+          let isOver = false;
           console.log(e.key);
-          if(e.key === "a") {
+          
+          if (e.key === "a") {
             result.textContent = 'Player 1 won!!';
-          } else if(e.key === "l") {
+            isOver = true;
+          } else if (e.key === "l") {
             result.textContent = 'Player 2 won!!';
+            isOver = true;
           }
 
-          document.removeEventListener('keydown', keyHandler);
-          setTimeout(reset, 5000);
+          if (isOver) {
+            document.removeEventListener('keydown', keyHandler);
+            setTimeout(reset, 5000);
+          }
         };
       }
     </script>


### PR DESCRIPTION
Based on the description on MDN, pressing a wrong key shouldn't end the game, right?

> Regardless of which one of the player control keys was pressed, remove the `keydown` event listener using `removeEventListener()` so that once the winning press has happened, no more keyboard input is possible to mess up the final game result.