### PR TITLE
removing eval() unnecessary and not recommended

### DIFF
--- a/javascript/oojs/advanced/oojs-class-inheritance-start.html
+++ b/javascript/oojs/advanced/oojs-class-inheritance-start.html
@@ -22,7 +22,7 @@
 
       btn.onclick = function() {
         const code = input.value;
-        para.textContent = eval(code);
+        para.textContent = code;
       }
 
       function Person(first, last, age, gender, interests) {


### PR DESCRIPTION
I don't know how much damage can be done, but if we input

`alert('hello')` we can see the code is run, and get the alert, so I'd be careful. Also, the (MDN article about eval)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval]  but I couldn't really go through.