### PR TITLE
Update 7_canvas_walking_animation.html - remove unnecessary calculation

### DIFF
--- a/javascript/apis/drawing-graphics/loops_animation/7_canvas_walking_animation.html
+++ b/javascript/apis/drawing-graphics/loops_animation/7_canvas_walking_animation.html
@@ -47,7 +47,7 @@
 
         if(posX > width/2) {
           newStartPos = -((width/2) + 102);
-          posX = Math.ceil(newStartPos / 13) * 13;
+          posX = Math.ceil(newStartPos);
           console.log(posX);
         } else {
           posX += 2;


### PR DESCRIPTION
if we take any whole number and add 2 to it in each iteration it will eventually be a multiple of 13
this sentence from the documentation: “This has to be a multiple of 13 because otherwise the previous code block won’t work, since posX would never equal a multiple of 13!”
is not correct