### PR TITLE
Update aria-tabbed-info-box.html - remove unnecessary argument

### DIFF
--- a/accessibility/aria/aria-tabbed-info-box.html
+++ b/accessibility/aria/aria-tabbed-info-box.html
@@ -121,7 +121,7 @@ let panels = document.querySelectorAll('.info-box article');
 
 for(let i = 0; i < tabs.length; i++) {
   let tab = tabs[i];
-  setTabHandler(tab, i);
+  setTabHandler(tab);
 }
 
 function setTab(e) {


### PR DESCRIPTION
the function setTabHandler has only one parameter, but called with two