### PR TITLE
add empty <p> element to automation/index.html

### DIFF
--- a/tools-testing/cross-browser-testing/automation/index.html
+++ b/tools-testing/cross-browser-testing/automation/index.html
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    <p></p>
     <script src="main.js"></script>
   </body>
 </html>

--- a/tools-testing/cross-browser-testing/automation/index.html
+++ b/tools-testing/cross-browser-testing/automation/index.html
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    <!-- Intentionally empty paragraph to demonstrate element removal by a markup corrector -->
     <p></p>
     <script src="main.js"></script>
   </body>


### PR DESCRIPTION
In the [Automated_testing ](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Automated_testing )article it's written:

> In the input version of the file, you may have noticed that we put an empty ```<p>``` element; htmltidy has removed this by the time the output file has been created.

but there is no ```<p>``` element here

