### PR TITLE
keypress event changed to keydown

### DIFF
--- a/javascript/building-blocks/tasks/events/marking.md
+++ b/javascript/building-blocks/tasks/events/marking.md
@@ -55,7 +55,7 @@ drawCircle(x, y, size);
 
 // Add your code here
 
-window.addEventListener('keypress', (e) => {
+window.addEventListener('keydown', (e) => {
   switch(e.key) {
     case 'a':
       x -= 2;


### PR DESCRIPTION
Since the *keypress* event has been deprecated I think it's better to use *keydown* event.

(I'm not sure if I'm totally right, I just stumbled upon that while learning. It's also my first pull request and couldn't find the rules I should follow, sorry.)