### PR TITLE
bad-for-loop: revert to var

### DIFF
--- a/tools-testing/cross-browser-testing/javascript/bad-for-loop.html
+++ b/tools-testing/cross-browser-testing/javascript/bad-for-loop.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <script>
-      for(let i = 1; i <= 10; i++) {
+      for(var i = 1; i <= 10; i++) {
         const para = document.createElement('p');
         para.textContent = 'This is paragraph ' + i + '.';
         document.body.appendChild(para);


### PR DESCRIPTION
This got turned from `var` to `let` at some point, which unfortunately (for the docs) turns it from a bad example into a good one. As discussed in https://github.com/mdn/learning-area/issues/312, using `let` scopes the value passed to the function so the example works. With `var` the function is called using the final global value of the variable, which is 11.