### PR TITLE
Update planets-data.html

### DIFF
--- a/html/tables/assessment-finished/planets-data.html
+++ b/html/tables/assessment-finished/planets-data.html
@@ -132,7 +132,7 @@
           <td></td>
         </tr>
         <tr>
-          <th colspan="2" scope="row">Dwarf planets</th>
+          <th colspan="2" scope="rowgroup">Dwarf planets</th>
           <th scope="row">Pluto</th>
           <td>0.0146</td>
           <td>2,370</td>


### PR DESCRIPTION
Scope tag for "Dwarf Planets" should be "rowgroup" instead of "row" as "Dwarf planets" is a group name for all "dwarf" ones, not only for"Pluto".