### PR TITLE
Reduce slice function

### DIFF
--- a/javascript/building-blocks/loops/guest-list.html
+++ b/javascript/building-blocks/loops/guest-list.html
@@ -31,8 +31,8 @@
       i++;
     } while(i < people.length);
 
-    refused.textContent = refused.textContent.slice(0,refused.textContent.length-2) + '.';
-    admitted.textContent = admitted.textContent.slice(0,admitted.textContent.length-2) + '.';
+    refused.textContent = refused.textContent.slice(0,-2) + '.';
+    admitted.textContent = admitted.textContent.slice(0,-2) + '.';
 
     </script>
 


### PR DESCRIPTION
Since the string.slice() function allows negative numbers as arguments, it can be written shorter.