### PR TITLE
Deleting duplicate css rule of article element.

### DIFF
--- a/css/css-layout/flexbox/flexbox-wrap0.html
+++ b/css/css-layout/flexbox/flexbox-wrap0.html
@@ -37,9 +37,6 @@
         flex-direction: row;
       }
 
-      article {
-        
-      }
 
 
     </style>


### PR DESCRIPTION
This duplicate rule is not having any declarations.

```
     article {
        
      }
```