### PR TITLE
8_canvas_drawing_app: Add a visible default value

### DIFF
--- a/javascript/apis/drawing-graphics/loops_animation/8_canvas_drawing_app.html
+++ b/javascript/apis/drawing-graphics/loops_animation/8_canvas_drawing_app.html
@@ -36,7 +36,7 @@
   </head>
   <body>
     <div class="toolbar">
-      <input type="color" aria-label="select pen color">
+      <input type="color" aria-label="select pen color" value="#ff0000">
       <input type="range" min="2" max="50" value="30" aria-label="select pen size"><span class="output">30</span>
       <button>Clear canvas</button>
     </div>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/10338

The default value for an input selector is black, which means that the drawing app starts as black on black - a little confusing for users. This sets the initial colour as red.