### PR TITLE
Payment form - label links to id not name

### DIFF
--- a/html/forms/html-form-structure/payment-form.html
+++ b/html/forms/html-form-structure/payment-form.html
@@ -82,7 +82,7 @@
                 <span>Expiration date:</span>
                 <strong><abbr title="required">*</abbr></strong>
               </label>
-              <input type="text" name="expiration" required="true" placeholder="MM/YY" pattern="^(0[1-9]|1[0-2])\/([0-9]{2})$">
+              <input type="text" id="expiration" required="true" placeholder="MM/YY" pattern="^(0[1-9]|1[0-2])\/([0-9]{2})$">
             </p>
         </section>
         <section>


### PR DESCRIPTION
Update to match https://github.com/mdn/content/pull/10690

@estelle noted that the `for` label in a form should point to an `id` rather than a `name`.