### PR TITLE
"em" no longer in code on MDN

### DIFF
--- a/html/forms/html-form-structure/payment-form.css
+++ b/html/forms/html-form-structure/payment-form.css
@@ -62,9 +62,3 @@ button {
 label {
   position: relative;
 }
-
-label em {
-  position: absolute;
-  right: 5px;
-  top: 20px;
-}


### PR DESCRIPTION
The  "em" portion of the code for the "Payment Form" is no longer used, making the CSS code for it unneeded. The code seems to use placeholder instead of an "em" tag in the label.