### PR TITLE
Fix two typos in Advanced HTML Text 1 from Test your skills: Advanced HTML text

### DIFF
--- a/html/introduction-to-html/tasks/advanced-text/advanced-text1.html
+++ b/html/introduction-to-html/tasks/advanced-text/advanced-text1.html
@@ -65,10 +65,10 @@ dt {
 <h1>Advanced HTML Animals</h1>
 
 Llama
-Tall, wooly quadraped, pointy ears. Sometimes rideable, but grumpy and spits a lot. Big fan of list items.
+Tall, wooly quadruped, pointy ears. Sometimes rideable, but grumpy and spits a lot. Big fan of list items.
 Anaconda
 A very large constrictor snake; travels rapidly by way of anchors to sneak up on his prey.
-Hiphopapotamus
+Hippopotamus
 His description is bottomless.
     </textarea>
 


### PR DESCRIPTION
I fixed a misspelling of "Hippopotamus" and a misspelling of "quadruped."