### PR TITLE
JS Learn: update client-side APIs, part 7

### DIFF
--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.js
@@ -1,24 +1,23 @@
-window.onload = function() {
-  // Create constants
-  const section = document.querySelector('section');
-  const videos = [
-    { 'name' : 'crystal' },
-    { 'name' : 'elf' },
-    { 'name' : 'frog' },
-    { 'name' : 'monster' },
-    { 'name' : 'pig' },
-    { 'name' : 'rabbit' }
-  ];
-  // Create an instance of a db object for us to store our database in
-  let db;
+// Create constants
+const section = document.querySelector('section');
+const videos = [
+  { 'name' : 'crystal' },
+  { 'name' : 'elf' },
+  { 'name' : 'frog' },
+  { 'name' : 'monster' },
+  { 'name' : 'pig' },
+  { 'name' : 'rabbit' }
+];
+// Create an instance of a db object for us to store our database in
+let db;
 
 function init() {
   // Loop through the video names one by one
-  for(let i = 0; i < videos.length; i++) {
+  for(const video of videos) {
     // Open transaction, get object store, and get() each video by name
-    let objectStore = db.transaction('videos').objectStore('videos');
-    let request = objectStore.get(videos[i].name);
-    request.onsuccess = function() {
+    const objectStore = db.transaction('videos_os').objectStore('videos_os');
+    const request = objectStore.get(video.name);
+    request.addEventListener('success', () => {
       // If the result exists in the database (is not undefined)
       if(request.result) {
         // Grab the videos from IDB and display them using displayVideo()
@@ -26,124 +25,110 @@ function init() {
         displayVideo(request.result.mp4, request.result.webm, request.result.name);
       } else {
         // Fetch the videos from the network
-        fetchVideoFromNetwork(videos[i]);
+        fetchVideoFromNetwork(video);
       }
-    };
+    });
   }
 }
 
-  // Define the fetchVideoFromNetwork() function
-  function fetchVideoFromNetwork(video) {
-    console.log('fetching videos from network');
-    // Fetch the MP4 and WebM versions of the video using the fetch() function,
-    // then expose their response bodies as blobs
-    let mp4Blob = fetch('videos/' + video.name + '.mp4').then(response =>
-      response.blob()
-    );
-    let webmBlob = fetch('videos/' + video.name + '.webm').then(response =>
-      response.blob()
-    );;
+// Define the fetchVideoFromNetwork() function
+function fetchVideoFromNetwork(video) {
+  console.log('fetching videos from network');
+  // Fetch the MP4 and WebM versions of the video using the fetch() function,
+  // then expose their response bodies as blobs
+  const mp4Blob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
+  const webmBlob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
 
-    // Only run the next code when both promises have fulfilled
-    Promise.all([mp4Blob, webmBlob]).then(function(values) {
-      // display the video fetched from the network with displayVideo()
-      displayVideo(values[0], values[1], video.name);
-      // store it in the IDB using storeVideo()
-      storeVideo(values[0], values[1], video.name);
-    });
-  }
+  // Only run the next code when both promises have fulfilled
+  Promise.all([mp4Blob, webmBlob]).then(values => {
+    // display the video fetched from the network with displayVideo()
+    displayVideo(values[0], values[1], video.name);
+    // store it in the IDB using storeVideo()
+    storeVideo(values[0], values[1], video.name);
+  });
+}
 
-  // Define the storeVideo() function
+// Define the storeVideo() function
 function storeVideo(mp4Blob, webmBlob, name) {
   // Open transaction, get object store; make it a readwrite so we can write to the IDB
-  let objectStore = db.transaction(['videos'], 'readwrite').objectStore('videos');
+  const objectStore = db.transaction(['videos_os'], 'readwrite').objectStore('videos_os');
   // Create a record to add to the IDB
-  let record = {
+  const record = {
     mp4 : mp4Blob,
     webm : webmBlob,
     name : name
   }
 
   // Add the record to the IDB using add()
-  let request = objectStore.add(record);
+  const request = objectStore.add(record);
 
-  request.onsuccess = function() {
-    console.log('Record addition attempt finished');
-  }
+  request.addEventListener('success', () => console.log('Record addition attempt finished'));
+  request.addEventListener('error', () => console.error(request.error));
+}
 
-  request.onerror = function() {
-    console.log(request.error);
-  }
+// Define the displayVideo() function
+function displayVideo(mp4Blob, webmBlob, title) {
+  // Create object URLs out of the blobs
+  const mp4URL = URL.createObjectURL(mp4Blob);
+  const webmURL = URL.createObjectURL(webmBlob);
 
-};
+  // Create DOM elements to embed video in the page
+  const article = document.createElement('article');
+  const h2 = document.createElement('h2');
+  h2.textContent = title;
+  const video = document.createElement('video');
+  video.controls = true;
+  const source1 = document.createElement('source');
+  source1.src = mp4URL;
+  source1.type = 'video/mp4';
+  const source2 = document.createElement('source');
+  source2.src = webmURL;
+  source2.type = 'video/webm';
 
-  // Define the displayVideo() function
-  function displayVideo(mp4Blob, webmBlob, title) {
-    // Create object URLs out of the blobs
-    let mp4URL = URL.createObjectURL(mp4Blob);
-    let webmURL = URL.createObjectURL(webmBlob);
+  // Embed DOM elements into page
+  section.appendChild(article);
+  article.appendChild(h2);
+  article.appendChild(video);
+  video.appendChild(source1);
+  video.appendChild(source2);
+}
 
-    // Create DOM elements to embed video in the page
-    const article = document.createElement('article');
-    const h2 = document.createElement('h2');
-    h2.textContent = title;
-    const video = document.createElement('video');
-    video.controls = true;
-    const source1 = document.createElement('source');
-    source1.src = mp4URL;
-    source1.type = 'video/mp4';
-    const source2 = document.createElement('source');
-    source2.src = webmURL;
-    source2.type = 'video/webm';
+// Open our database; it is created if it doesn't already exist
+// (see upgradeneeded below)
+const request = window.indexedDB.open('videos_db', 1);
 
-    // Embed DOM elements into page
-    section.appendChild(article);
-    article.appendChild(h2);
-    article.appendChild(video);
-    video.appendChild(source1);
-    video.appendChild(source2);
-  }
+// error handler signifies that the database didn't open successfully
+request.addEventListener('error', () => console.error('Database failed to open'));
 
-  // Open our database; it is created if it doesn't already exist
-  // (see onupgradeneeded below)
-  let request = window.indexedDB.open('videos', 1);
+// success handler signifies that the database opened successfully
+request.addEventListener('success', () => {
+  console.log('Database opened succesfully');
 
-  // onerror handler signifies that the database didn't open successfully
-  request.onerror = function() {
-    console.log('Database failed to open');
-  };
+  // Store the opened database object in the db variable. This is used a lot below
+  db = request.result;
+  init();
+});
 
-  // onsuccess handler signifies that the database opened successfully
-  request.onsuccess = function() {
-    console.log('Database opened succesfully');
+// Setup the database tables if this has not already been done
+request.addEventListener('upgradeneeded', e => {
 
-    // Store the opened database object in the db variable. This is used a lot below
-    db = request.result;
-    init();
-  };
+  // Grab a reference to the opened database
+  const db = e.target.result;
 
-  // Setup the database tables if this has not already been done
-  request.onupgradeneeded = function(e) {
+  // Create an objectStore to store our videos in (basically like a single table)
+  // including a auto-incrementing key
+  const objectStore = db.createObjectStore('videos_os', { keyPath: 'name' });
 
-    // Grab a reference to the opened database
-    let db = e.target.result;
+  // Define what data items the objectStore will contain
+  objectStore.createIndex('mp4', 'mp4', { unique: false });
+  objectStore.createIndex('webm', 'webm', { unique: false });
 
-    // Create an objectStore to store our notes in (basically like a single table)
-    // including a auto-incrementing key
-    let objectStore = db.createObjectStore('videos', { keyPath: 'name' });
+  console.log('Database setup complete');
+});
 
-    // Define what data items the objectStore will contain
-    objectStore.createIndex('mp4', 'mp4', { unique: false });
-    objectStore.createIndex('webm', 'webm', { unique: false });
-
-    console.log('Database setup complete');
-  };
-
-  // Register service worker to control making site work offline
-
-  if('serviceWorker' in navigator) {
-    navigator.serviceWorker
-             .register('/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js')
-             .then(function() { console.log('Service Worker Registered'); });
-  }
-};
+// Register service worker to control making site work offline
+if('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js')
+    .then(() => console.log('Service Worker Registered'));
+}

--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
@@ -14,8 +14,6 @@ self.addEventListener('install', e => {
 self.addEventListener('fetch', e => {
   console.log(e.request.url);
   e.respondWith(
-    caches.match(e.request).then(response => {
-      return response || fetch(e.request);
-    })
+    caches.match(e.request).then(response => response || fetch(e.request))
   );
 });

--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
@@ -1,6 +1,6 @@
-self.addEventListener('install', function(e) {
+self.addEventListener('install', e => {
  e.waitUntil(
-   caches.open('video-store').then(function(cache) {
+   caches.open('video-store').then(cache => {
      return cache.addAll([
        '/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/',
        '/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.html',
@@ -11,11 +11,10 @@ self.addEventListener('install', function(e) {
  );
 });
 
-self.addEventListener('fetch', function(e) {
+self.addEventListener('fetch', e => {
   console.log(e.request.url);
   e.respondWith(
-    caches.match(e.request).then(function(response) {
-      return response || fetch(e.request);
-    })
+    caches.match(e.request)
+      .then(response => response || fetch(e.request));
   );
 });

--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
@@ -1,6 +1,6 @@
-self.addEventListener('install', e => {
+self.addEventListener('install', function(e) {
  e.waitUntil(
-   caches.open('video-store').then(cache => {
+   caches.open('video-store').then(function(cache) {
      return cache.addAll([
        '/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/',
        '/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.html',
@@ -11,10 +11,11 @@ self.addEventListener('install', e => {
  );
 });
 
-self.addEventListener('fetch', e => {
+self.addEventListener('fetch', function(e) {
   console.log(e.request.url);
   e.respondWith(
-    caches.match(e.request)
-      .then(response => response || fetch(e.request));
+    caches.match(e.request).then(function(response) {
+      return response || fetch(e.request);
+    })
   );
 });

--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/sw.js
@@ -1,4 +1,4 @@
-self.addEventListener('install', function(e) {
+self.addEventListener('install', e => {
  e.waitUntil(
    caches.open('video-store').then(function(cache) {
      return cache.addAll([
@@ -11,10 +11,10 @@ self.addEventListener('install', function(e) {
  );
 });
 
-self.addEventListener('fetch', function(e) {
+self.addEventListener('fetch', e => {
   console.log(e.request.url);
   e.respondWith(
-    caches.match(e.request).then(function(response) {
+    caches.match(e.request).then(response => {
       return response || fetch(e.request);
     })
   );

--- a/javascript/apis/client-side-storage/indexeddb/notes/index.js
+++ b/javascript/apis/client-side-storage/indexeddb/notes/index.js
@@ -8,167 +8,161 @@ const submitBtn = document.querySelector('form button');
 // Create an instance of a db object for us to store the open database in
 let db;
 
-window.onload = function() {
-  // Open our database; it is created if it doesn't already exist
-  // (see onupgradeneeded below)
-  let request = window.indexedDB.open('notes_db', 1);
+// Open our database; it is created if it doesn't already exist
+// (see the upgradeneeded handler below)
+const openRequest = window.indexedDB.open('notes_db', 1);
 
-  // onerror handler signifies that the database didn't open successfully
-  request.onerror = function() {
-    console.log('Database failed to open');
-  };
+// error handler signifies that the database didn't open successfully
+openRequest.addEventListener('error', () => console.error('Database failed to open'));
 
-  // onsuccess handler signifies that the database opened successfully
-  request.onsuccess = function() {
-    console.log('Database opened succesfully');
+// success handler signifies that the database opened successfully
+openRequest.addEventListener('success', () => {
+  console.log('Database opened succesfully');
 
-    // Store the opened database object in the db variable. This is used a lot below
-    db = request.result;
+  // Store the opened database object in the db variable. This is used a lot below
+  db = openRequest.result;
 
-    // Run the displayData() function to display the notes already in the IDB
+  // Run the displayData() function to display the notes already in the IDB
+  displayData();
+});
+
+// Set up the database tables if this has not already been done
+openRequest.addEventListener('upgradeneeded', e => {
+
+  // Grab a reference to the opened database
+  db = e.target.result;
+
+  // Create an objectStore to store our notes in (basically like a single table)
+  // including a auto-incrementing key
+  const objectStore = db.createObjectStore('notes_os', { keyPath: 'id', autoIncrement:true });
+
+  // Define what data items the objectStore will contain
+  objectStore.createIndex('title', 'title', { unique: false });
+  objectStore.createIndex('body', 'body', { unique: false });
+
+  console.log('Database setup complete');
+});
+
+// Create an submit handler so that when the form is submitted the addData() function is run
+form.addEventListener('submit', addData);
+
+// Define the addData() function
+function addData(e) {
+  // prevent default - we don't want the form to submit in the conventional way
+  e.preventDefault();
+
+  // grab the values entered into the form fields and store them in an object ready for being inserted into the DB
+  const newItem = { title: titleInput.value, body: bodyInput.value };
+
+  // open a read/write db transaction, ready for adding the data
+  const transaction = db.transaction(['notes_os'], 'readwrite');
+
+  // call an object store that's already been added to the database
+  const objectStore = transaction.objectStore('notes_os');
+
+  // Make a request to add our newItem object to the object store
+  const addRequest = objectStore.add(newItem);
+
+  addRequest.addEventListener('success', () => {
+    // Clear the form, ready for adding the next entry
+    titleInput.value = '';
+    bodyInput.value = '';
+  });
+
+  // Report on the success of the transaction completing, when everything is done
+  transaction.addEventListener('complete', () => {
+    console.log('Transaction completed: database modification finished.');
+
+    // update the display of data to show the newly added item, by running displayData() again.
     displayData();
-  };
+  });
 
-  // Setup the database tables if this has not already been done
-  request.onupgradeneeded = function(e) {
+  transaction.addEventListener('error', () => console.log('Transaction not opened due to error'));
+}
 
-    // Grab a reference to the opened database
-    let db = e.target.result;
-
-    // Create an objectStore to store our notes in (basically like a single table)
-    // including a auto-incrementing key
-    let objectStore = db.createObjectStore('notes_os', { keyPath: 'id', autoIncrement:true });
-
-    // Define what data items the objectStore will contain
-    objectStore.createIndex('title', 'title', { unique: false });
-    objectStore.createIndex('body', 'body', { unique: false });
-
-    console.log('Database setup complete');
-  };
-
-  // Create an onsubmit handler so that when the form is submitted the addData() function is run
-  form.onsubmit = addData;
-
-  // Define the addData() function
-  function addData(e) {
-    // prevent default - we don't want the form to submit in the conventional way
-    e.preventDefault();
-
-    // grab the values entered into the form fields and store them in an object ready for being inserted into the DB
-    let newItem = { title: titleInput.value, body: bodyInput.value };
-
-    // open a read/write db transaction, ready for adding the data
-    let transaction = db.transaction(['notes_os'], 'readwrite');
-
-    // call an object store that's already been added to the database
-    let objectStore = transaction.objectStore('notes_os');
-
-    // Make a request to add our newItem object to the object store
-    var request = objectStore.add(newItem);
-    request.onsuccess = function() {
-      // Clear the form, ready for adding the next entry
-      titleInput.value = '';
-      bodyInput.value = '';
-    };
-
-    // Report on the success of the transaction completing, when everything is done
-    transaction.oncomplete = function() {
-      console.log('Transaction completed: database modification finished.');
-
-      // update the display of data to show the newly added item, by running displayData() again.
-      displayData();
-    };
-
-    transaction.onerror = function() {
-      console.log('Transaction not opened due to error');
-    };
+// Define the displayData() function
+function displayData() {
+  // Here we empty the contents of the list element each time the display is updated
+  // If you ddn't do this, you'd get duplicates listed each time a new note is added
+  while (list.firstChild) {
+    list.removeChild(list.firstChild);
   }
 
-  // Define the displayData() function
-  function displayData() {
-    // Here we empty the contents of the list element each time the display is updated
-    // If you ddn't do this, you'd get duplicates listed each time a new note is added
-    while (list.firstChild) {
-      list.removeChild(list.firstChild);
-    }
+  // Open our object store and then get a cursor - which iterates through all the
+  // different data items in the store
+  const objectStore = db.transaction('notes_os').objectStore('notes_os');
+  objectStore.openCursor().addEventListener('success', e => {
+    // Get a reference to the cursor
+    const cursor = e.target.result;
 
-    // Open our object store and then get a cursor - which iterates through all the
-    // different data items in the store
-    let objectStore = db.transaction('notes_os').objectStore('notes_os');
-    objectStore.openCursor().onsuccess = function(e) {
-      // Get a reference to the cursor
-      let cursor = e.target.result;
+    // If there is still another data item to iterate through, keep running this code
+    if(cursor) {
+      // Create a list item, h3, and p to put each data item inside when displaying it
+      // structure the HTML fragment, and append it inside the list
+      const listItem = document.createElement('li');
+      const h3 = document.createElement('h3');
+      const para = document.createElement('p');
 
-      // If there is still another data item to iterate through, keep running this code
-      if(cursor) {
-        // Create a list item, h3, and p to put each data item inside when displaying it
-        // structure the HTML fragment, and append it inside the list
-        const listItem = document.createElement('li');
-        const h3 = document.createElement('h3');
-        const para = document.createElement('p');
+      listItem.appendChild(h3);
+      listItem.appendChild(para);
+      list.appendChild(listItem);
 
-        listItem.appendChild(h3);
-        listItem.appendChild(para);
-        list.appendChild(listItem);
+      // Put the data from the cursor inside the h3 and para
+      h3.textContent = cursor.value.title;
+      para.textContent = cursor.value.body;
 
-        // Put the data from the cursor inside the h3 and para
-        h3.textContent = cursor.value.title;
-        para.textContent = cursor.value.body;
+      // Store the ID of the data item inside an attribute on the listItem, so we know
+      // which item it corresponds to. This will be useful later when we want to delete items
+      listItem.setAttribute('data-note-id', cursor.value.id);
 
-        // Store the ID of the data item inside an attribute on the listItem, so we know
-        // which item it corresponds to. This will be useful later when we want to delete items
-        listItem.setAttribute('data-note-id', cursor.value.id);
+      // Create a button and place it inside each listItem
+      const deleteBtn = document.createElement('button');
+      listItem.appendChild(deleteBtn);
+      deleteBtn.textContent = 'Delete';
 
-        // Create a button and place it inside each listItem
-        const deleteBtn = document.createElement('button');
-        listItem.appendChild(deleteBtn);
-        deleteBtn.textContent = 'Delete';
+      // Set an event handler so that when the button is clicked, the deleteItem()
+      // function is run
+      deleteBtn.addEventListener('click', deleteItem);
 
-        // Set an event handler so that when the button is clicked, the deleteItem()
-        // function is run
-        deleteBtn.onclick = deleteItem;
-
-        // Iterate to the next item in the cursor
-        cursor.continue();
-      } else {
-        // Again, if list item is empty, display a 'No notes stored' message
-        if(!list.firstChild) {
-          const listItem = document.createElement('li');
-          listItem.textContent = 'No notes stored.'
-          list.appendChild(listItem);
-        }
-        // if there are no more cursor items to iterate through, say so
-        console.log('Notes all displayed');
-      }
-    };
-  }
-
-  // Define the deleteItem() function
-  function deleteItem(e) {
-    // retrieve the name of the task we want to delete. We need
-    // to convert it to a number before trying it use it with IDB; IDB key
-    // values are type-sensitive.
-    let noteId = Number(e.target.parentNode.getAttribute('data-note-id'));
-
-    // open a database transaction and delete the task, finding it using the id we retrieved above
-    let transaction = db.transaction(['notes_os'], 'readwrite');
-    let objectStore = transaction.objectStore('notes_os');
-    let request = objectStore.delete(noteId);
-
-    // report that the data item has been deleted
-    transaction.oncomplete = function() {
-      // delete the parent of the button
-      // which is the list item, so it is no longer displayed
-      e.target.parentNode.parentNode.removeChild(e.target.parentNode);
-      console.log('Note ' + noteId + ' deleted.');
-
+      // Iterate to the next item in the cursor
+      cursor.continue();
+    } else {
       // Again, if list item is empty, display a 'No notes stored' message
       if(!list.firstChild) {
         const listItem = document.createElement('li');
-        listItem.textContent = 'No notes stored.';
+        listItem.textContent = 'No notes stored.'
         list.appendChild(listItem);
       }
-    };
-  }
+      // if there are no more cursor items to iterate through, say so
+      console.log('Notes all displayed');
+    }
+  });
+}
 
-};
+// Define the deleteItem() function
+function deleteItem(e) {
+  // retrieve the name of the task we want to delete. We need
+  // to convert it to a number before trying it use it with IDB; IDB key
+  // values are type-sensitive.
+  const noteId = Number(e.target.parentNode.getAttribute('data-note-id'));
+
+  // open a database transaction and delete the task, finding it using the id we retrieved above
+  const transaction = db.transaction(['notes_os'], 'readwrite');
+  const objectStore = transaction.objectStore('notes_os');
+  const deleteRequest = objectStore.delete(noteId);
+
+  // report that the data item has been deleted
+  transaction.addEventListener('complete', () => {
+    // delete the parent of the button
+    // which is the list item, so it is no longer displayed
+    e.target.parentNode.parentNode.removeChild(e.target.parentNode);
+    console.log(`Note ${noteId} deleted.`);
+
+    // Again, if list item is empty, display a 'No notes stored' message
+    if(!list.firstChild) {
+      const listItem = document.createElement('li');
+      listItem.textContent = 'No notes stored.';
+      list.appendChild(listItem);
+    }
+  });
+}

--- a/javascript/apis/client-side-storage/indexeddb/video-store/index.js
+++ b/javascript/apis/client-side-storage/indexeddb/video-store/index.js
@@ -1,24 +1,23 @@
-window.onload = function() {
-  // Create constants
-  const section = document.querySelector('section');
-  const videos = [
-    { 'name' : 'crystal' },
-    { 'name' : 'elf' },
-    { 'name' : 'frog' },
-    { 'name' : 'monster' },
-    { 'name' : 'pig' },
-    { 'name' : 'rabbit' }
-  ];
-  // Create an instance of a db object for us to store our database in
-  let db;
+// Create constants
+const section = document.querySelector('section');
+const videos = [
+  { 'name' : 'crystal' },
+  { 'name' : 'elf' },
+  { 'name' : 'frog' },
+  { 'name' : 'monster' },
+  { 'name' : 'pig' },
+  { 'name' : 'rabbit' }
+];
+// Create an instance of a db object for us to store our database in
+let db;
 
 function init() {
   // Loop through the video names one by one
-  for(let i = 0; i < videos.length; i++) {
+  for(const video of videos) {
     // Open transaction, get object store, and get() each video by name
-    let objectStore = db.transaction('videos_os').objectStore('videos_os');
-    let request = objectStore.get(videos[i].name);
-    request.onsuccess = function() {
+    const objectStore = db.transaction('videos_os').objectStore('videos_os');
+    const request = objectStore.get(video.name);
+    request.addEventListener('success', () => {
       // If the result exists in the database (is not undefined)
       if(request.result) {
         // Grab the videos from IDB and display them using displayVideo()
@@ -26,116 +25,103 @@ function init() {
         displayVideo(request.result.mp4, request.result.webm, request.result.name);
       } else {
         // Fetch the videos from the network
-        fetchVideoFromNetwork(videos[i]);
+        fetchVideoFromNetwork(video);
       }
-    };
+    });
   }
 }
 
-  // Define the fetchVideoFromNetwork() function
-  function fetchVideoFromNetwork(video) {
-    console.log('fetching videos from network');
-    // Fetch the MP4 and WebM versions of the video using the fetch() function,
-    // then expose their response bodies as blobs
-    let mp4Blob = fetch('videos/' + video.name + '.mp4').then(response =>
-      response.blob()
-    );
-    let webmBlob = fetch('videos/' + video.name + '.webm').then(response =>
-      response.blob()
-    );
+// Define the fetchVideoFromNetwork() function
+function fetchVideoFromNetwork(video) {
+  console.log('fetching videos from network');
+  // Fetch the MP4 and WebM versions of the video using the fetch() function,
+  // then expose their response bodies as blobs
+  const mp4Blob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
+  const webmBlob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
 
-    // Only run the next code when both promises have fulfilled
-    Promise.all([mp4Blob, webmBlob]).then(function(values) {
-      // display the video fetched from the network with displayVideo()
-      displayVideo(values[0], values[1], video.name);
-      // store it in the IDB using storeVideo()
-      storeVideo(values[0], values[1], video.name);
-    });
-  }
+  // Only run the next code when both promises have fulfilled
+  Promise.all([mp4Blob, webmBlob]).then(values => {
+    // display the video fetched from the network with displayVideo()
+    displayVideo(values[0], values[1], video.name);
+    // store it in the IDB using storeVideo()
+    storeVideo(values[0], values[1], video.name);
+  });
+}
 
-  // Define the storeVideo() function
+// Define the storeVideo() function
 function storeVideo(mp4Blob, webmBlob, name) {
   // Open transaction, get object store; make it a readwrite so we can write to the IDB
-  let objectStore = db.transaction(['videos_os'], 'readwrite').objectStore('videos_os');
+  const objectStore = db.transaction(['videos_os'], 'readwrite').objectStore('videos_os');
   // Create a record to add to the IDB
-  let record = {
+  const record = {
     mp4 : mp4Blob,
     webm : webmBlob,
     name : name
   }
 
   // Add the record to the IDB using add()
-  let request = objectStore.add(record);
+  const request = objectStore.add(record);
 
-  request.onsuccess = function() {
-    console.log('Record addition attempt finished');
-  }
+  request.addEventListener('success', () => console.log('Record addition attempt finished'));
+  request.addEventListener('error', () => console.error(request.error));
+}
 
-  request.onerror = function() {
-    console.log(request.error);
-  }
+// Define the displayVideo() function
+function displayVideo(mp4Blob, webmBlob, title) {
+  // Create object URLs out of the blobs
+  const mp4URL = URL.createObjectURL(mp4Blob);
+  const webmURL = URL.createObjectURL(webmBlob);
 
-};
+  // Create DOM elements to embed video in the page
+  const article = document.createElement('article');
+  const h2 = document.createElement('h2');
+  h2.textContent = title;
+  const video = document.createElement('video');
+  video.controls = true;
+  const source1 = document.createElement('source');
+  source1.src = mp4URL;
+  source1.type = 'video/mp4';
+  const source2 = document.createElement('source');
+  source2.src = webmURL;
+  source2.type = 'video/webm';
 
-  // Define the displayVideo() function
-  function displayVideo(mp4Blob, webmBlob, title) {
-    // Create object URLs out of the blobs
-    let mp4URL = URL.createObjectURL(mp4Blob);
-    let webmURL = URL.createObjectURL(webmBlob);
+  // Embed DOM elements into page
+  section.appendChild(article);
+  article.appendChild(h2);
+  article.appendChild(video);
+  video.appendChild(source1);
+  video.appendChild(source2);
+}
 
-    // Create DOM elements to embed video in the page
-    const article = document.createElement('article');
-    const h2 = document.createElement('h2');
-    h2.textContent = title;
-    const video = document.createElement('video');
-    video.controls = true;
-    const source1 = document.createElement('source');
-    source1.src = mp4URL;
-    source1.type = 'video/mp4';
-    const source2 = document.createElement('source');
-    source2.src = webmURL;
-    source2.type = 'video/webm';
+// Open our database; it is created if it doesn't already exist
+// (see upgradeneeded below)
+const request = window.indexedDB.open('videos_db', 1);
 
-    // Embed DOM elements into page
-    section.appendChild(article);
-    article.appendChild(h2);
-    article.appendChild(video);
-    video.appendChild(source1);
-    video.appendChild(source2);
-  }
+// error handler signifies that the database didn't open successfully
+request.addEventListener('error', () => console.error('Database failed to open'));
 
-  // Open our database; it is created if it doesn't already exist
-  // (see onupgradeneeded below)
-  let request = window.indexedDB.open('videos_db', 1);
+// success handler signifies that the database opened successfully
+request.addEventListener('success', () => {
+  console.log('Database opened succesfully');
 
-  // onerror handler signifies that the database didn't open successfully
-  request.onerror = function() {
-    console.log('Database failed to open');
-  };
+  // Store the opened database object in the db variable. This is used a lot below
+  db = request.result;
+  init();
+});
 
-  // onsuccess handler signifies that the database opened successfully
-  request.onsuccess = function() {
-    console.log('Database opened succesfully');
+// Setup the database tables if this has not already been done
+request.addEventListener('upgradeneeded', e => {
 
-    // Store the opened database object in the db variable. This is used a lot below
-    db = request.result;
-    init();
-  };
+  // Grab a reference to the opened database
+  const db = e.target.result;
 
-  // Setup the database tables if this has not already been done
-  request.onupgradeneeded = function(e) {
+  // Create an objectStore to store our videos in (basically like a single table)
+  // including a auto-incrementing key
+  const objectStore = db.createObjectStore('videos_os', { keyPath: 'name' });
 
-    // Grab a reference to the opened database
-    let db = e.target.result;
+  // Define what data items the objectStore will contain
+  objectStore.createIndex('mp4', 'mp4', { unique: false });
+  objectStore.createIndex('webm', 'webm', { unique: false });
 
-    // Create an objectStore to store our videos in (basically like a single table)
-    // including a auto-incrementing key
-    let objectStore = db.createObjectStore('videos_os', { keyPath: 'name' });
-
-    // Define what data items the objectStore will contain
-    objectStore.createIndex('mp4', 'mp4', { unique: false });
-    objectStore.createIndex('webm', 'webm', { unique: false });
-
-    console.log('Database setup complete');
-  };
-};
+  console.log('Database setup complete');
+});

--- a/javascript/apis/client-side-storage/web-storage/index.js
+++ b/javascript/apis/client-side-storage/web-storage/index.js
@@ -10,12 +10,10 @@ const h1 = document.querySelector('h1');
 const personalGreeting = document.querySelector('.personal-greeting');
 
 // Stop the form from submitting when a button is pressed
-form.addEventListener('submit', function(e) {
-  e.preventDefault();
-});
+form.addEventListener('submit', e => e.preventDefault());
 
 // run function when the 'Say hello' button is clicked
-submitBtn.addEventListener('click', function() {
+submitBtn.addEventListener('click', () => {
   // store the entered name in web storage
   localStorage.setItem('name', nameInput.value);
   // run nameDisplayCheck() to sort out displaying the personalised greetings and updating the form display
@@ -23,7 +21,7 @@ submitBtn.addEventListener('click', function() {
 });
 
 // run function when the 'Forget' button is clicked
-forgetBtn.addEventListener('click', function() {
+forgetBtn.addEventListener('click', () => {
   // Remove the stored name from web storage
   localStorage.removeItem('name');
   // run nameDisplayCheck() to sort out displaying the generic greeting again and updating the form display
@@ -35,9 +33,9 @@ function nameDisplayCheck() {
   // check whether the 'name' data item is stored in web Storage
   if(localStorage.getItem('name')) {
     // If it is, display personalized greeting
-    let name = localStorage.getItem('name');
-    h1.textContent = 'Welcome, ' + name;
-    personalGreeting.textContent = 'Welcome to our website, ' + name + '! We hope you have fun while you are here.';
+    const name = localStorage.getItem('name');
+    h1.textContent = `Welcome, ${name}`;
+    personalGreeting.textContent = `Welcome to our website, ${name}! We hope you have fun while you are here.`;
     // hide the 'remember' part of the form and show the 'forget' part
     forgetDiv.style.display = 'block';
     rememberDiv.style.display = 'none';
@@ -51,6 +49,6 @@ function nameDisplayCheck() {
   }
 }
 
-// run nameDisplayCheck() when the DOM first loads to check wether a personal name was previously
+// run nameDisplayCheck() when the page first loads to check wether a personal name was previously
 // set, and if so display the personalized greeting. If not, show the generic greeting
-document.body.onload = nameDisplayCheck;
+nameDisplayCheck();


### PR DESCRIPTION
This is the learning-area PR corresponding to https://github.com/mdn/content/pull/13467.

I think it's not possible to test the service worker example locally, but I set my fork's GitHub page source to this branch, so you should be able to try it out at https://wbamberg.github.io/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/.

One change here worth mentioning is that I removed the `window.onload()` stuff, because AFAICT using the `defer` attribute in the `<script>` tag should ensure that the script doesn't run until the page is loaded, right?

Marking as draft because this and https://github.com/mdn/content/pull/13467 should be merged together, and changes in one will need corresponding changes in the other one.

But this is ready for review.