### PR TITLE
Remove closing tag for stylesheet

### DIFF
--- a/javascript/asynchronous/workers/finished/index.html
+++ b/javascript/asynchronous/workers/finished/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <script type="text/javascript" src="main.js" defer></script>
-    <link href="style.css"rel="stylesheet"></link>
+    <link href="style.css"rel="stylesheet">
   </head>
 
   <body>

--- a/javascript/asynchronous/workers/start/index.html
+++ b/javascript/asynchronous/workers/start/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <script type="text/javascript" src="main.js" defer></script>
-    <link href="style.css"rel="stylesheet"></link>
+    <link href="style.css"rel="stylesheet">
   </head>
 
   <body>


### PR DESCRIPTION
Trying to fix the <a href='https://github.com/mdn/content/issues/14142'>issue</a> with closing tag for the stylesheet.

Although HTML file works without any complain, there is no need for the link closing tag.