### PR TITLE
Removing 'this'

### DIFF
--- a/javascript/apis/introduction/web-audio/index.html
+++ b/javascript/apis/introduction/web-audio/index.html
@@ -62,7 +62,7 @@ audioElement.addEventListener('ended', () => {
 const gainNode = audioCtx.createGain();
 
 volumeSlider.addEventListener('input', () => {
-	gainNode.gain.value = this.value;
+	gainNode.gain.value = volumeSlider.value;
 });
 
 // connect our graph


### PR DESCRIPTION
Arrow functions does not have their own 'this' context.
Replacing 'this' with 'volumeSlider' to access value property OR we can replace the arrow function with 'function ()' and use 'this' to access value.