### PR TITLE
Remove typemustmatch attribute

### DIFF
--- a/html/multimedia-and-embedding/other-embedding-technologies/object-image.html
+++ b/html/multimedia-and-embedding/other-embedding-technologies/object-image.html
@@ -8,7 +8,7 @@
     <h1>Object element example</h1>
 
  
-    <object data="dinosaur.jpg" type="image/jpeg" width="400" height="341" typemustmatch>
+    <object data="dinosaur.jpg" type="image/jpeg" width="400" height="341">
       <p>Why oh why didn't we just use the image element?</p>
     </object>
 

--- a/html/multimedia-and-embedding/other-embedding-technologies/object-pdf.html
+++ b/html/multimedia-and-embedding/other-embedding-technologies/object-pdf.html
@@ -8,7 +8,7 @@
     <h1>Object element example</h1>
 
  
-    <object data="mypdf.pdf" type="application/pdf" width="800" height="1200" typemustmatch>
+    <object data="mypdf.pdf" type="application/pdf" width="800" height="1200">
       <p>You don't have a PDF plugin, but you can <a href="mypdf.pdf">download the PDF file.</a></p>
     </object>
 

--- a/html/multimedia-and-embedding/tasks/media-embed/marking.md
+++ b/html/multimedia-and-embedding/tasks/media-embed/marking.md
@@ -53,7 +53,7 @@ The finished code would probably look like something this:
 <h1>Embedding</h1>
 
 <object data="media/mypdf.pdf" type="application/pdf"
-        width="400" height="400" typemustmatch>
+        width="400" height="400">
 </object>
 
 <hr>


### PR DESCRIPTION
The `typemustmatch` attribute was removed from the spec and subsequently from MDN.
We still use it in two live examples and the marking guide. This PR removes them.

Background: https://github.com/mdn/content/pull/3655