### PR TITLE
Make mailto anchor work inside iframe

### DIFF
--- a/html/introduction-to-html/tasks/links/links1.html
+++ b/html/introduction-to-html/tasks/links/links1.html
@@ -25,7 +25,7 @@
       <p>For more information on our conservation activities and which Whales we study,
       see our <a target="_blank">Whales page</a>.</p>
 
-      <p>If you want to ask our team more questions, feel free to <a>email us</a>.</p>
+      <p>If you want to ask our team more questions, feel free to <a target="_blank">email us</a>.</p>
 
     </section>
 
@@ -41,7 +41,7 @@ p {
 <p>For more information on our conservation activities and which Whales we study,
 see our <a target="_blank">Whales page</a>.</p>
 
-<p>If you want to ask our team more questions, feel free to <a>email us</a>.</p>
+<p>If you want to ask our team more questions, feel free to <a target="_blank">email us</a>.</p>
     </textarea>
 
     <div class="playable-buttons">


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/20436.

In Chrome Version 105 (MacOS Monterey and default mail app) clicking on the mailto link causes an error (iframe) in the [first interactive example](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Test_your_skills:_Links#task_1):
<img width="547" alt="Screen Shot 2022-05-08 at 18 07 47" src="https://user-images.githubusercontent.com/95487764/167304896-4ab9be99-2215-4dbc-ac96-5dee610d9163.png">

In Safari nothing happens on click in my case (no error and no mail window).
In Firefox it seems to work without any problems.

My solution is giving the `<a>` element the attribute `target="_blank"`. Is `_top` or `_parent` better/more correct in this case?
Maybe another solution?

Note that the "note box" in this task has to be updated too in mdn/content. (just changing "The first link..." to "The links...")
