### PR TITLE
fix(readonly-confirmation): fix read-only prefix error

### DIFF
--- a/html/forms/pseudo-classes/readonly-confirmation.html
+++ b/html/forms/pseudo-classes/readonly-confirmation.html
@@ -61,16 +61,29 @@
         margin: 20px auto;
       }
 
-      input:-moz-read-only, textarea:-moz-read-only,
-      input:read-only, textarea:read-only {
+      input:-moz-read-only,
+      textarea:-moz-read-only {
         border: 0;
         box-shadow: none;
         background-color: white;
       }
 
-      textarea:-moz-read-write,
-      textarea:read-write {
+      input:read-only,
+      textarea:read-only {
+        border: 0;
+        -webkit-box-shadow: none;
+                box-shadow: none;
+        background-color: white;
+      }
+
+      textarea:-moz-read-write {
         box-shadow: inset 1px 1px 3px #ccc;
+        border-radius: 5px;
+      }
+
+      textarea:read-write {
+        -webkit-box-shadow: inset 1px 1px 3px #ccc;
+                box-shadow: inset 1px 1px 3px #ccc;
         border-radius: 5px;
       }
     </style>

--- a/html/forms/pseudo-classes/readonly-confirmation.html
+++ b/html/forms/pseudo-classes/readonly-confirmation.html
@@ -61,27 +61,14 @@
         margin: 20px auto;
       }
 
-      input:-moz-read-only,
-      textarea:-moz-read-only {
-        border: 0;
-        box-shadow: none;
-        background-color: white;
-      }
-
-      input:read-only,
-      textarea:read-only {
+      :is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
         border: 0;
         -webkit-box-shadow: none;
                 box-shadow: none;
         background-color: white;
       }
 
-      textarea:-moz-read-write {
-        box-shadow: inset 1px 1px 3px #ccc;
-        border-radius: 5px;
-      }
-
-      textarea:read-write {
+      :is(textarea:-moz-read-write, textarea:read-write) {
         -webkit-box-shadow: inset 1px 1px 3px #ccc;
                 box-shadow: inset 1px 1px 3px #ccc;
         border-radius: 5px;

--- a/html/forms/pseudo-classes/readonly-confirmation.html
+++ b/html/forms/pseudo-classes/readonly-confirmation.html
@@ -63,14 +63,12 @@
 
       :is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
         border: 0;
-        -webkit-box-shadow: none;
-                box-shadow: none;
+        box-shadow: none;
         background-color: white;
       }
 
       :is(textarea:-moz-read-write, textarea:read-write) {
-        -webkit-box-shadow: inset 1px 1px 3px #ccc;
-                box-shadow: inset 1px 1px 3px #ccc;
+        box-shadow: inset 1px 1px 3px #ccc;
         border-radius: 5px;
       }
     </style>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- fix CSS error in `:read-only` example

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- `:read-only` CSS is not working properly in Chorme.
- `-moz-` prefix won't work with Chome browser.
- Chome ignores whole CSS block with invalid prefix.

*As-Is*
<img width="542" alt="image" src="https://user-images.githubusercontent.com/73219421/173220104-f2087f86-74f2-4fd5-b6db-40822c16b4a4.png">
*To-Be*
<img width="532" alt="image" src="https://user-images.githubusercontent.com/73219421/173220087-4c6fec46-0c80-4450-b07d-a14b1d43117b.png">

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
> A selector always goes together with a declaration block.
> When a user agent cannot parse the selector (i.e., it is not valid CSS 2.1),
> it must ignore the selector and the following declaration block (if any) as well.
> &mdash; [4.1.7 Rule sets, declaration blocks, and selectors](<https://www.w3.org/TR/CSS21/syndata.html#rule-sets:~:text=A%20selector%20always%20goes%20together%20with%20a%20declaration%20block.%20When%20a%20user%20agent%20cannot%20parse%20the%20selector%20(i.e.%2C%20it%20is%20not%20valid%20CSS%C2%A02.1)%2C%20it%20must%20ignore%20the%20selector%20and%20the%20following%20declaration%20block%20(if%20any)%20as%20well.>)

- [autoprefixer](https://autoprefixer.github.io/) result
```css
/* input */
input:read-only,
textarea:read-only {
  border: 0;
  box-shadow: none;
  background-color: white;
}
```

```css
/* output */
input:-moz-read-only, textarea:-moz-read-only {
  border: 0;
  box-shadow: none;
  background-color: white;
}
input:read-only,
textarea:read-only {
  border: 0;
  -webkit-box-shadow: none;
          box-shadow: none;
  background-color: white;
}
```


