### PR TITLE
remove unnecessary ARIA roles

### DIFF
--- a/accessibility/aria/website-aria-roles/index.html
+++ b/accessibility/aria/website-aria-roles/index.html
@@ -17,7 +17,7 @@
 
       <!-- Even is it's not mandatory, it's common practice to put the main navigation menu within the main header -->
 
-      <nav role="navigation">
+      <nav>
         <ul>
           <li><a href="#">Home</a></li>
           <li><a href="#">Our team</a></li>
@@ -38,7 +38,7 @@
     <main>
 
       <!-- It contains an article -->
-      <article role="article">
+      <article>
         <h2>Article heading</h2>
 
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Donec a diam lectus. Set sit amet ipsum mauris. Maecenas congue ligula as quam viverra nec consectetur ant hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur.</p>
@@ -57,7 +57,7 @@
       </article>
 
       <!-- the aside content can also be nested within the main content -->
-      <aside role="complementary">
+      <aside>
         <h2>Related</h2>
 
         <ul>


### PR DESCRIPTION
I'm currently making a PR for the wai-aria_basics file and in it there was reference to the markup of this file, where redundant ARIA roles were added to elements which had already been noted as exposing these semantics by default.  

As i'm removing these useless roles from the example in the referenced file, they should be removed from this example as well.