### PR TITLE
fix typo in index.js of video-store-offline example

### DIFF
--- a/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.js
+++ b/javascript/apis/client-side-storage/cache-sw/video-store-offline/index.js
@@ -37,7 +37,7 @@ function fetchVideoFromNetwork(video) {
   // Fetch the MP4 and WebM versions of the video using the fetch() function,
   // then expose their response bodies as blobs
   const mp4Blob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
-  const webmBlob = fetch(`videos/${video.name}.mp4`).then(response => response.blob());
+  const webmBlob = fetch(`videos/${video.name}.webm`).then(response => response.blob());
 
   // Only run the next code when both promises have fulfilled
   Promise.all([mp4Blob, webmBlob]).then(values => {


### PR DESCRIPTION
fix typo in index.js located in video-store-offline example.