### PR TITLE
Remove CSS box for HTML forms tasks

### DIFF
--- a/html/forms/tasks/basic-controls/basic-controls1.html
+++ b/html/forms/tasks/basic-controls/basic-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/basic-controls/basic-controls2.html
+++ b/html/forms/tasks/basic-controls/basic-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/basic-controls/basic-controls3.html
+++ b/html/forms/tasks/basic-controls/basic-controls3.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/form-structure/form-structure1.html
+++ b/html/forms/tasks/form-structure/form-structure1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/html5-controls/html5-controls1.html
+++ b/html/forms/tasks/html5-controls/html5-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/html5-controls/html5-controls2.html
+++ b/html/forms/tasks/html5-controls/html5-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/other-controls/other-controls1.html
+++ b/html/forms/tasks/other-controls/other-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/other-controls/other-controls2.html
+++ b/html/forms/tasks/other-controls/other-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/other-controls/other-controls3.html
+++ b/html/forms/tasks/other-controls/other-controls3.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    <textarea class="playable playable-css" style="height: 130px;">
-
     </textarea>
 
     <textarea class="playable playable-html" style="height: 220px;">

--- a/html/forms/tasks/playable.js
+++ b/html/forms/tasks/playable.js
@@ -1,22 +1,24 @@
-var section = document.querySelector('section');
-var editable = document.querySelector('.editable');
-var textareaHTML = document.querySelector('.playable-html');
-var textareaCSS = document.querySelector('.playable-css');
-var reset = document.getElementById('reset');
+var section = document.querySelector("section");
+var editable = document.querySelector(".editable");
+var textareaHTML = document.querySelector(".playable-html");
+var textareaCSS = document.querySelector(".playable-css");
+var reset = document.getElementById("reset");
 var htmlCode = textareaHTML.value;
-var cssCode = textareaCSS.value;
+var cssCode = textareaCSS?.value;
 
 function fillCode() {
-    editable.innerHTML = textareaCSS.value;
-    section.innerHTML = textareaHTML.value;
+  editable.innerHTML = textareaCSS?.value;
+  section.innerHTML = textareaHTML.value;
 }
 
-reset.addEventListener('click', function () {
-    textareaHTML.value = htmlCode;
+reset.addEventListener("click", function () {
+  textareaHTML.value = htmlCode;
+  if (textareaCSS) {
     textareaCSS.value = cssCode;
-    fillCode();
+  }
+  fillCode();
 });
 
-textareaHTML.addEventListener('input', fillCode);
-textareaCSS.addEventListener('input', fillCode);
-window.addEventListener('load', fillCode);
+textareaHTML.addEventListener("input", fillCode);
+textareaCSS?.addEventListener("input", fillCode);
+window.addEventListener("load", fillCode);


### PR DESCRIPTION
In most of the "Test your skills" tasks for the HTML Forms module, the learner is only asked to provide HTML. But the editor also include an empty box for CSS, and this is confusing - because the box is empty, there's no indication that it is for CSS, and it might tempt people to try to add HTML in there.

For example: https://developer.mozilla.org/en-US/docs/Learn/Forms/Test_your_skills:_Other_controls#other_controls_1 .

This might have contributed to the confusion in https://github.com/mdn/content/issues/23776 (although that has other sources too).

So in this PR I've removed the CSS box from all editors under HTML/Forms except in the cases where the learner is actually expected to add CSS.

Maybe it would also be good to label the boxes?