### PR TITLE
Fix dangling textarea closing tags

### DIFF
--- a/html/forms/tasks/basic-controls/basic-controls1.html
+++ b/html/forms/tasks/basic-controls/basic-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <ul>

--- a/html/forms/tasks/basic-controls/basic-controls2.html
+++ b/html/forms/tasks/basic-controls/basic-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
       <form>
         <fieldset>

--- a/html/forms/tasks/basic-controls/basic-controls3.html
+++ b/html/forms/tasks/basic-controls/basic-controls3.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
     <ul>

--- a/html/forms/tasks/form-structure/form-structure1.html
+++ b/html/forms/tasks/form-structure/form-structure1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   Name:

--- a/html/forms/tasks/html5-controls/html5-controls1.html
+++ b/html/forms/tasks/html5-controls/html5-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <h2>Edit your preferences</h2>

--- a/html/forms/tasks/html5-controls/html5-controls2.html
+++ b/html/forms/tasks/html5-controls/html5-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <ul>

--- a/html/forms/tasks/other-controls/other-controls1.html
+++ b/html/forms/tasks/other-controls/other-controls1.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <h2>Enter your comment</h2>

--- a/html/forms/tasks/other-controls/other-controls2.html
+++ b/html/forms/tasks/other-controls/other-controls2.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <ul>

--- a/html/forms/tasks/other-controls/other-controls3.html
+++ b/html/forms/tasks/other-controls/other-controls3.html
@@ -30,8 +30,6 @@
 
     </section>
 
-    </textarea>
-
     <textarea class="playable playable-html" style="height: 220px;">
 <form>
   <ul>


### PR DESCRIPTION
I merged #588 too quickly - noticed afterwards that the removal of the textarea elements did not include the end tag. This removes the end tags too.

FYI @wbamberg 