### PR TITLE
"outline: transparent;" instead of "outline: none;"

### DIFF
--- a/html/forms/tasks/advanced-styling/marking.md
+++ b/html/forms/tasks/advanced-styling/marking.md
@@ -11,7 +11,7 @@ We've already provided you with a basic reset to build upon.
 1. First of all, try giving the search box a consistent width, height, padding, and border color across browsers. This is pretty self-explanatory; `line-height` tends to work better than `height` for keeping a consistent height in which the input text is vertically-centered. 
 2. You'll find that some browsers will not behave in terms of the form element's height. This is due to native OS styling being used in some cases. How can you remove this native styling? The answer here is `-webkit-appearance: none;`.
 3. Once you've removed the native styling, you'll need to add back one of the features it was providing, to keep same look and feel we originally had. How do you do this? Answer: rounded corners! We need `border-radius`.
-4. One thing that is inconsistent across browsers (particularly looking at Safari here) is the position of the standard blue focus outline. How can you remove this? Answer: `outline: none;`
+4. One thing that is inconsistent across browsers (particularly looking at Safari here) is the position of the standard blue focus outline. How can you remove this? Answer: `outline: transparent;`
 5. There is a major problem with just getting rid of the blue focus outline. What is it? Can you add some kind of styling back in so that users can tell when the search box is being hovered or focused? Answer: Use some kind of styling applied to the input using the `:hover` and `:focus` pseudo-classes.
 6. Another thing that commonly denotes a search box is a magnifying glass icon. We've made one available in the same directory as `search-24px.png`, plus a `<div>` element after the search input to help you attach it, should you need it. Can you figure out a sensible way to attach it, and can you use some CSS to get it to sit to the right of the search box, and be lined up vertically as well? Answer: There are many ways to do this, but the easiest is probably to make it a background image of the `<div>`, and then use flexbox to line it up.
 
@@ -48,7 +48,7 @@ input[type="search"] {
   -webkit-appearance: none;
   border-radius: 6px;
 
-  outline: none;
+  outline: transparent;
 }
 
 input[type="search"]:hover, input[type="search"]:focus {


### PR DESCRIPTION
It may be preferable to specify a transparent outline. It preserves function for high contrast mode users. (Box shadow isn't applied in that mode.)

Some discussion of this principle here:
https://dev.to/eevajonnapanula/dont-set-outline-0-or-outline-none-for-focus-styles-2olb