### PR TITLE
chore(html): use const, format code example

### DIFF
--- a/html/introduction-to-html/advanced-text-formatting/other-semantics.html
+++ b/html/introduction-to-html/advanced-text-formatting/other-semantics.html
@@ -1,14 +1,20 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>Other semantics examples</title>
   </head>
   <body>
-    <p>We use <abbr>HTML</abbr>, Hypertext Markup Language, to structure our web documents.</p>
+    <p>
+      We use <abbr>HTML</abbr>, Hypertext Markup Language, to structure our web
+      documents.
+    </p>
 
-    <p>I think <abbr title="Reverend">Rev.</abbr> Green did it in the kitchen with the chainsaw.</p>
+    <p>
+      I think <abbr title="Reverend">Rev.</abbr> Green did it in the kitchen
+      with the chainsaw.
+    </p>
 
     <address>
       <p>Chris Mills, Manchester, The Grim North, UK</p>
@@ -16,25 +22,35 @@
 
     <p>My birthday is on the 25<sup>th</sup> of May 2001.</p>
 
-    <p>Caffeine's chemical formula is C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub>.</p>
+    <p>
+      Caffeine's chemical formula is
+      C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub>.
+    </p>
 
     <p>If x<sup>2</sup> is 9, x must equal 3.</p>
 
-    <pre><code>var para = document.querySelector('p');
+    <pre><code>const para = document.querySelector('p');
 
 para.onclick = function() {
   alert('Owww, stop poking me!');
 }</code></pre>
 
-    <p>You shouldn't use presentational elements like <code>&lt;font&gt;</code> and <code>&lt;center&gt;</code>.</p>
+    <p>
+      You shouldn't use presentational elements like
+      <code>&lt;font&gt;</code> and <code>&lt;center&gt;</code>.
+    </p>
 
-    <p>In the above JavaScript example, <var>para</var> represents a paragraph element.</p>
+    <p>
+      In the above JavaScript example, <var>para</var> represents a paragraph
+      element.
+    </p>
 
-    <p>Select all the text with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>A</kbd>.</p>
+    <p>
+      Select all the text with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>A</kbd>.
+    </p>
 
     <pre>$ <kbd>ping mozilla.org</kbd>
 <samp>PING mozilla.org (63.245.215.20): 56 data bytes
 64 bytes from 63.245.215.20: icmp_seq=0 ttl=40 time=158.233 ms</samp></pre>
-
   </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/25750 :

>I expected the github link to display the same code that is in the snippet below the code, or vice versa. They should match.

See https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting#representing_computer_code