### PR TITLE
fix(forms): add margin to form for readability

### DIFF
--- a/html/forms/form-validation/fruit-length.html
+++ b/html/forms/form-validation/fruit-length.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>Favorite fruit length constraint</title>
     <style>
       input:invalid {
@@ -14,25 +14,34 @@
       }
 
       div {
-        margin-bottom: 10px;
+        margin-bottom: 1rem;
+      }
+      form {
+        margin: 2rem 0 2rem 0;
       }
     </style>
   </head>
 
-<body>
+  <body>
     <form>
       <div>
         <label for="choose">Would you prefer a banana or a cherry?</label>
-        <input id="choose" name="i_like" required minlength="6" maxlength="6">
+        <input id="choose" name="i_like" required minlength="6" maxlength="6" />
       </div>
       <div>
         <label for="number">How many would you like?</label>
-        <input type="number" id="number" name="amount" value="1" min="1" max="10">
+        <input
+          type="number"
+          id="number"
+          name="amount"
+          value="1"
+          min="1"
+          max="10"
+        />
       </div>
       <div>
         <button>Submit</button>
       </div>
     </form>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
The validity error message has a low z-index on Chrome, so it's occluded by the rest of the page in an iframe. This makes the example at https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#constraining_the_values_of_your_entries have a semi-occluded validity message.

This PR adds some padding so that the message is visible when constraint validation fails.

<details>
<summary>Screenshot:</summary>

![image](https://github.com/mdn/learning-area/assets/43580235/21eada27-6c23-4a1e-86b5-7442bd2ccd20)


</details>