### PR TITLE
Remove prefixed :read-only selectors

### DIFF
--- a/html/forms/pseudo-classes/readonly-confirmation.html
+++ b/html/forms/pseudo-classes/readonly-confirmation.html
@@ -62,13 +62,13 @@
         margin: 20px auto;
       }
 
-      :is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
+      input:read-only, textarea:read-only {
         border: 0;
         box-shadow: none;
         background-color: white;
       }
 
-      :is(textarea:-moz-read-write, textarea:read-write) {
+      textarea:read-write {
         box-shadow: inset 1px 1px 3px #ccc;
         border-radius: 5px;
       }


### PR DESCRIPTION
Firefox supports the unprefixed selector since version 78, released on June 2020.

By removing the prefixed selectors, we can in turn remove the `:is()` pseudo-class, which was needed for its forgiving selector list.