### PR TITLE
Improve Advanced Table Examples (A11y, headers attribute)

### DIFF
--- a/html/tables/advanced/items-sold-headers.html
+++ b/html/tables/advanced/items-sold-headers.html
@@ -12,67 +12,64 @@
 
     <table>
       <caption>Items Sold August 2016</caption>
-        <thead>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th colspan="3" id="clothes">Clothes</th>
-            <th colspan="2" id="accessories">Accessories</th>
-          </tr>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th id="trousers">Trousers</th>
-            <th id="skirts">Skirts</th>
-            <th id="dresses">Dresses</th>
-            <th id="bracelets">Bracelets</th>
-            <th id="rings">Rings</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th rowspan="3" id="belgium">Belgium</th>
-            <th id="antwerp">Antwerp</th>
-            <td headers="clothes trousers belgium antwerp">56</td>
-            <td headers="clothes skirts belgium antwerp">22</td>
-            <td headers="clothes dresses belgium antwerp">43</td>
-            <td headers="accessories bracelets belgium antwerp">72</td>
-            <td headers="accessories rings belgium antwerp">23</td>
-          </tr>
-          <tr>
-            <th id="gent">Gent</th>
-            <td headers="clothes trousers belgium gent">46</td>
-            <td headers="clothes skirts belgium gent">18</td>
-            <td headers="clothes dresses belgium gent">50</td>
-            <td headers="accessories bracelets belgium gent">61</td>
-            <td headers="accessories rings belgium gent">15</td>
-         </tr>
-         <tr>
-           <th id="brussels">Brussels</th>
-           <td headers="clothes trousers belgium brussels">51</td>
-           <td headers="clothes skirts belgium brussels">27</td>
-           <td headers="clothes dresses belgium brussels">38</td>
-           <td headers="accessories bracelets belgium brussels">69</td>
-           <td headers="accessories rings belgium brussels">28</td>
-         </tr>
-         <tr>
-           <th rowspan="2" id="netherlands">The Netherlands</th>
-           <th id="amsterdam">Amsterdam</th>
-           <td headers="clothes trousers netherlands amsterdam">89</td>
-           <td headers="clothes skirts netherlands amsterdam">34</td>
-           <td headers="clothes dresses netherlands amsterdam">69</td>
-           <td headers="accessories bracelets netherlands amsterdam">85</td>
-           <td headers="accessories rings netherlands amsterdam">38</td>
-         </tr>
-         <tr>
-           <th id="utrecht">Utrecht</th>
-           <td headers="clothes trousers netherlands utrecht">80</td>
-           <td headers="clothes skirts netherlands utrecht">12</td>
-           <td headers="clothes dresses netherlands utrecht">43</td>
-           <td headers="accessories bracelets netherlands utrecht">36</td>
-           <td headers="accessories rings netherlands utrecht">19</td>
-         </tr>
-       </tbody>
+      <thead>
+        <tr>
+          <td colspan="2" rowspan="2"></td>
+          <th colspan="3" id="clothes">Clothes</th>
+          <th colspan="2" id="accessories">Accessories</th>
+        </tr>
+        <tr>
+          <th id="trousers" headers="clothes">Trousers</th>
+          <th id="skirts" headers="clothes">Skirts</th>
+          <th id="dresses" headers="clothes">Dresses</th>
+          <th id="bracelets" headers="accessories">Bracelets</th>
+          <th id="rings" headers="accessories">Rings</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th rowspan="3" id="belgium">Belgium</th>
+          <th id="antwerp" headers="belgium">Antwerp</th>
+          <td headers="antwerp belgium clothes trousers">56</td>
+          <td headers="antwerp belgium clothes skirts">22</td>
+          <td headers="antwerp belgium clothes dresses">43</td>
+          <td headers="antwerp belgium accessories bracelets">72</td>
+          <td headers="antwerp belgium accessories rings">23</td>
+        </tr>
+        <tr>
+          <th id="gent" headers="belgium">Gent</th>
+          <td headers="gent belgium clothes trousers">46</td>
+          <td headers="gent belgium clothes skirts">18</td>
+          <td headers="gent belgium clothes dresses">50</td>
+          <td headers="gent belgium accessories bracelets">61</td>
+          <td headers="gent belgium accessories rings">15</td>
+        </tr>
+        <tr>
+          <th id="brussels" headers="belgium">Brussels</th>
+          <td headers="brussels belgium clothes trousers">51</td>
+          <td headers="brussels belgium clothes skirts">27</td>
+          <td headers="brussels belgium clothes dresses">38</td>
+          <td headers="brussels belgium accessories bracelets">69</td>
+          <td headers="brussels belgium accessories rings">28</td>
+        </tr>
+        <tr>
+          <th rowspan="2" id="netherlands">The Netherlands</th>
+          <th id="amsterdam" headers="netherlands">Amsterdam</th>
+          <td headers="amsterdam netherlands clothes trousers">89</td>
+          <td headers="amsterdam netherlands clothes skirts">34</td>
+          <td headers="amsterdam netherlands clothes dresses">69</td>
+          <td headers="amsterdam netherlands accessories bracelets">85</td>
+          <td headers="amsterdam netherlands accessories rings">38</td>
+        </tr>
+        <tr>
+          <th id="utrecht" headers="netherlands">Utrecht</th>
+          <td headers="utrecht netherlands clothes trousers">80</td>
+          <td headers="utrecht netherlands clothes skirts">12</td>
+          <td headers="utrecht netherlands clothes dresses">43</td>
+          <td headers="utrecht netherlands accessories bracelets">36</td>
+          <td headers="utrecht netherlands accessories rings">19</td>
+        </tr>
+      </tbody>
     </table>
 
 </body>

--- a/html/tables/advanced/items-sold-scope.html
+++ b/html/tables/advanced/items-sold-scope.html
@@ -12,67 +12,64 @@
 
     <table>
       <caption>Items Sold August 2016</caption>
-        <thead>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th colspan="3" scope="colgroup">Clothes</th>
-            <th colspan="2" scope="colgroup">Accessories</th>
-          </tr>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th scope="col">Trousers</th>
-            <th scope="col">Skirts</th>
-            <th scope="col">Dresses</th>
-            <th scope="col">Bracelets</th>
-            <th scope="col">Rings</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th rowspan="3" scope="rowgroup">Belgium</th>
-            <th scope="row">Antwerp</th>
-            <td>56</td>
-            <td>22</td>
-            <td>43</td>
-            <td>72</td>
-            <td>23</td>
-          </tr>
-          <tr>
-            <th scope="row">Gent</th>
-            <td>46</td>
-            <td>18</td>
-            <td>50</td>
-            <td>61</td>
-            <td>15</td>
-         </tr>
-         <tr>
-           <th scope="row">Brussels</th>
-           <td>51</td>
-           <td>27</td>
-           <td>38</td>
-           <td>69</td>
-           <td>28</td>
-         </tr>
-         <tr>
-           <th rowspan="2" scope="rowgroup">The Netherlands</th>
-           <th scope="row">Amsterdam</th>
-           <td>89</td>
-           <td>34</td>
-           <td>69</td>
-           <td>85</td>
-           <td>38</td>
-         </tr>
-         <tr>
-           <th scope="row">Utrecht</th>
-           <td>80</td>
-           <td>12</td>
-           <td>43</td>
-           <td>36</td>
-           <td>19</td>
-         </tr>
-       </tbody>
+      <thead>
+        <tr>
+          <td colspan="2" rowspan="2"></td>
+          <th colspan="3" scope="colgroup">Clothes</th>
+          <th colspan="2" scope="colgroup">Accessories</th>
+        </tr>
+        <tr>
+          <th scope="col">Trousers</th>
+          <th scope="col">Skirts</th>
+          <th scope="col">Dresses</th>
+          <th scope="col">Bracelets</th>
+          <th scope="col">Rings</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th rowspan="3" scope="rowgroup">Belgium</th>
+          <th scope="row">Antwerp</th>
+          <td>56</td>
+          <td>22</td>
+          <td>43</td>
+          <td>72</td>
+          <td>23</td>
+        </tr>
+        <tr>
+          <th scope="row">Gent</th>
+          <td>46</td>
+          <td>18</td>
+          <td>50</td>
+          <td>61</td>
+          <td>15</td>
+        </tr>
+        <tr>
+          <th scope="row">Brussels</th>
+          <td>51</td>
+          <td>27</td>
+          <td>38</td>
+          <td>69</td>
+          <td>28</td>
+        </tr>
+        <tr>
+          <th rowspan="2" scope="rowgroup">The Netherlands</th>
+          <th scope="row">Amsterdam</th>
+          <td>89</td>
+          <td>34</td>
+          <td>69</td>
+          <td>85</td>
+          <td>38</td>
+        </tr>
+        <tr>
+          <th scope="row">Utrecht</th>
+          <td>80</td>
+          <td>12</td>
+          <td>43</td>
+          <td>36</td>
+          <td>19</td>
+        </tr>
+      </tbody>
     </table>
 
 </body>

--- a/html/tables/advanced/items-sold.html
+++ b/html/tables/advanced/items-sold.html
@@ -12,67 +12,64 @@
 
     <table>
       <caption>Items Sold August 2016</caption>
-        <thead>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th colspan="3">Clothes</th>
-            <th colspan="2">Accessories</th>
-          </tr>
-          <tr>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <th>Trousers</th>
-            <th>Skirts</th>
-            <th>Dresses</th>
-            <th>Bracelets</th>
-            <th>Rings</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th rowspan="3">Belgium</th>
-            <th>Antwerp</th>
-            <td>56</td>
-            <td>22</td>
-            <td>43</td>
-            <td>72</td>
-            <td>23</td>
-          </tr>
-          <tr>
-            <th>Gent</th>
-            <td>46</td>
-            <td>18</td>
-            <td>50</td>
-            <td>61</td>
-            <td>15</td>
-         </tr>
-         <tr>
-           <th>Brussels</th>
-           <td>51</td>
-           <td>27</td>
-           <td>38</td>
-           <td>69</td>
-           <td>28</td>
-         </tr>
-         <tr>
-           <th rowspan="2">The Netherlands</th>
-           <th>Amsterdam</th>
-           <td>89</td>
-           <td>34</td>
-           <td>69</td>
-           <td>85</td>
-           <td>38</td>
-         </tr>
-         <tr>
-           <th>Utrecht</th>
-           <td>80</td>
-           <td>12</td>
-           <td>43</td>
-           <td>36</td>
-           <td>19</td>
-         </tr>
-       </tbody>
+      <thead>
+        <tr>
+          <td colspan="2" rowspan="2"></td>
+          <th colspan="3">Clothes</th>
+          <th colspan="2">Accessories</th>
+        </tr>
+        <tr>
+          <th>Trousers</th>
+          <th>Skirts</th>
+          <th>Dresses</th>
+          <th>Bracelets</th>
+          <th>Rings</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th rowspan="3">Belgium</th>
+          <th>Antwerp</th>
+          <td>56</td>
+          <td>22</td>
+          <td>43</td>
+          <td>72</td>
+          <td>23</td>
+        </tr>
+        <tr>
+          <th>Gent</th>
+          <td>46</td>
+          <td>18</td>
+          <td>50</td>
+          <td>61</td>
+          <td>15</td>
+        </tr>
+        <tr>
+          <th>Brussels</th>
+          <td>51</td>
+          <td>27</td>
+          <td>38</td>
+          <td>69</td>
+          <td>28</td>
+        </tr>
+        <tr>
+          <th rowspan="2">The Netherlands</th>
+          <th>Amsterdam</th>
+          <td>89</td>
+          <td>34</td>
+          <td>69</td>
+          <td>85</td>
+          <td>38</td>
+        </tr>
+        <tr>
+          <th>Utrecht</th>
+          <td>80</td>
+          <td>12</td>
+          <td>43</td>
+          <td>36</td>
+          <td>19</td>
+        </tr>
+      </tbody>
     </table>
 
 </body>


### PR DESCRIPTION
For the fix of https://github.com/mdn/content/issues/29654