### PR TITLE
Change order of tbody and tfoot in tables/advanced

### DIFF
--- a/html/tables/advanced/spending-record-finished.html
+++ b/html/tables/advanced/spending-record-finished.html
@@ -30,12 +30,6 @@
             <th>Cost (€)</th>
           </tr>
         </thead>
-        <tfoot>
-          <tr>
-            <td colspan="4">SUM</td>
-            <td>118</td>
-          </tr>
-        </tfoot>
         <tbody>
           <tr>
             <td>Haircut</td>
@@ -66,6 +60,12 @@
             <td>5</td>
           </tr>
         </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="4">SUM</td>
+            <td>118</td>
+          </tr>
+        </tfoot>
     </table>
 
   </body>


### PR DESCRIPTION
The matching MDN article has been updated to state the order that `<thead>`, `<tbody>` and `<tfoot>` should be in, according to the HTML spec. For some more background on this, take a look at https://github.com/mdn/content/pull/32909

Since this table appears in that page, it should be updated to follow the guidance in that page. 

I looked at the other tables in this directory, and didn't see any more with a `<tfoot>`, so I think this is the only one. 