### PR TITLE
Text updates on variable change

### DIFF
--- a/javascript/introduction-to-js-1/maths/editable_canvas.html
+++ b/javascript/introduction-to-js-1/maths/editable_canvas.html
@@ -101,10 +101,28 @@ ctx.fillRect(10, 10, x, y);
     let code = textarea.value;
 
     function drawCanvas() {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      eval(textarea.value);
-      para.textContent = `The rectangle is ${x}px wide and ${y}px high.`;
-    }
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const lines = textarea.value.split('\n');
+
+  // Find the lines that assign values to x and y
+  const xLine = lines.find(line => line.trim().startsWith('x ='));
+  const yLine = lines.find(line => line.trim().startsWith('y ='));
+
+  if (xLine && yLine) {
+    const x = eval(xLine.split('=')[1].trim());
+    const y = eval(yLine.split('=')[1].trim());
+
+    ctx.fillStyle = 'green';
+    ctx.fillRect(10, 10, x, y);
+
+    // Update the text content of the <p> element
+    para.textContent = `The rectangle is ${x}px wide and ${y}px high.`;
+  } else {
+    // Handle the case when x or y is not assigned
+    para.textContent = 'The rectangle is not defined.';
+  }
+}
+
 
     reset.addEventListener('click', function() {
       textarea.value = code; drawCanvas();


### PR DESCRIPTION
MDN URL

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math
What specific section or headline is this issue about?

Active learning: sizing a canvas box
What information was incorrect, unhelpful, or incomplete?

When changing values of X and Y in the code, I was expecting the string below the canvas to update to the new X and Y values. But they always show: "The rectangle is 50px wide and 50px high."
What did you expect to see?

I was expecting for it to update when the values were changed in each exercise
Do you have any supporting links, references, or citations?

No response
Do you have anything more you want to share?

No response
MDN metadata
Page report details

    Folder: en-us/learn/javascript/first_steps/math
    MDN URL: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math
    GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/learn/javascript/first_steps/math/index.md
    Last commit: https://github.com/mdn/content/commit/151cdeeba58ffc07f8673af4e303cb1fcbba1bff
    Document last modified: 2024-04-29T15:59:22.000Z

Pull request to answer:  #33540
The text now changes with user input. 