### PR TITLE
Reintroduced intentional referenceError for tutorial

### DIFF
--- a/javascript/oojs/tasks/object-basics/object-basics1-download.html
+++ b/javascript/oojs/tasks/object-basics/object-basics1-download.html
@@ -46,7 +46,7 @@
     let para1 = document.createElement('p');
     let para2 = document.createElement('p');
 
-    para1.textContent = `The cat's name is ${ cat.name }.`;
+    para1.textContent = `The cat's name is ${ catName }.`;
     para2.textContent = `The cat's color is ${ cat.color }.`;
 
     section.appendChild(para1);


### PR DESCRIPTION
Fixed someone's previous commit, this was **meant** to return a referenceError that was then to be fixed by the tutorial taker by creating a variable 'catError' and assigning it the cat.name value.

This same line can be seen in the live preview found at [Live Preview HTML](https://github.com/mdn/learning-area/blob/main/javascript/oojs/tasks/object-basics/object-basics1.html). 

Tutorial 'Test your skills: Object basics - Object Basics 1' does not make sense without it.
