### PR TITLE
fix(css): use buttons instead of links and checkboxes in positioning examples

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "bracketSameLine": true
+}

--- a/css/css-layout/practical-positioning-examples/fixed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/fixed-info-box.html
@@ -37,15 +37,12 @@
       }
 
       .info-box [role="tab"] {
-        display: inline-block;
-        padding: 0 1rem 0 1rem;
-        text-decoration: none;
-        line-height: 3rem;
-        background: white;
-        color: #b60000;
-        text-align: center;
-        font-weight: bold;
         border: none;
+        background: white;
+        padding: 0 1rem 0 1rem;
+        line-height: 3rem;
+        color: #b60000;
+        font-weight: bold;
         outline: none;
       }
 
@@ -64,9 +61,9 @@
       /* styling info-box panels */
 
       .info-box .panels {
+        height: 352px;
         clear: both;
         position: relative;
-        height: 352px;
       }
 
       .info-box [role="tabpanel"] {
@@ -91,6 +88,10 @@
         padding: 10px;
         height: 2000px;
         margin-left: 470px;
+      }
+
+      .fake-content p {
+        margin-bottom: 200px;
       }
     </style>
   </head>
@@ -138,8 +139,7 @@
           type="button"
           role="tab"
           aria-selected="true"
-          aria-controls="tabpanel-1"
-        >
+          aria-controls="tabpanel-1">
           <span>Tab 1</span>
         </button>
 
@@ -148,8 +148,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-2"
-        >
+          aria-controls="tabpanel-2">
           <span>Tab 2</span>
         </button>
         <button
@@ -157,8 +156,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-3"
-        >
+          aria-controls="tabpanel-3">
           <span>Tab 3</span>
         </button>
       </div>

--- a/css/css-layout/practical-positioning-examples/fixed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/fixed-info-box.html
@@ -29,37 +29,31 @@
         top: 0;
       }
 
-      /* styling info-box list */
+      /* styling info-box tabs */
 
-      .info-box ul {
-        border: 1px solid #b60000;
-        overflow: hidden;
-        height: 50px;
-        margin: 0;
-        padding: 0;
-      }
-
-      .info-box li {
-        float: left;
-        list-style-type: none;
-        width: 150px;
+      .info-box [role="tablist"] {
+        min-width: 100%;
+        display: flex;
       }
 
       .info-box [role="tab"] {
         display: inline-block;
+        padding: 0 1rem 0 1rem;
         text-decoration: none;
-        width: 100%;
-        line-height: 3;
+        line-height: 3rem;
         background: white;
         color: #b60000;
         text-align: center;
         font-weight: bold;
+        border: none;
+        outline: none;
       }
 
-      .info-box [role="tab"]:focus,
-      .info-box [role="tab"]:hover {
-        background-color: #b6000099;
-        color: white;
+      .info-box [role="tab"]:focus span,
+      .info-box [role="tab"]:hover span {
+        outline: 1px solid blue;
+        outline-offset: 6px;
+        border-radius: 4px;
       }
 
       .info-box [role="tab"][aria-selected="true"] {
@@ -67,7 +61,7 @@
         color: white;
       }
 
-      /* styling info-box panles */
+      /* styling info-box panels */
 
       .info-box .panels {
         clear: both;
@@ -79,13 +73,13 @@
         background-color: #b60000;
         color: white;
         position: absolute;
-        padding: 10px 20px;
+        padding: 0.8rem 1.2rem;
         height: 352px;
         top: 0;
         left: 0;
       }
 
-      .info-box [role="tabpanel"].hidden {
+      .info-box [role="tabpanel"].is-hidden {
         display: none;
       }
 
@@ -138,41 +132,36 @@
     </section>
 
     <section class="info-box">
-      <ul>
-        <li>
-          <button
-            id="tab-1"
-            type="button"
-            role="tab"
-            aria-selected="true"
-            aria-controls="tabpanel-1"
-          >
-            Tab 1
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-2"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-2"
-          >
-            Tab 2
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-3"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-3"
-          >
-            Tab 3
-          </button>
-        </li>
-      </ul>
+      <div role="tablist" class="manual">
+        <button
+          id="tab-1"
+          type="button"
+          role="tab"
+          aria-selected="true"
+          aria-controls="tabpanel-1"
+        >
+          <span>Tab 1</span>
+        </button>
+
+        <button
+          id="tab-2"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-2"
+        >
+          <span>Tab 2</span>
+        </button>
+        <button
+          id="tab-3"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-3"
+        >
+          <span>Tab 3</span>
+        </button>
+      </div>
 
       <div class="panels">
         <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
@@ -188,12 +177,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-2"
-          role="tabpanel"
-          aria-labelledby="tab-2"
-          class="hidden"
-        >
+        <article id="tabpanel-2" role="tabpanel" aria-labelledby="tab-2">
           <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
@@ -201,12 +185,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-3"
-          role="tabpanel"
-          aria-labelledby="tab-3"
-          class="hidden"
-        >
+        <article id="tabpanel-3" role="tabpanel" aria-labelledby="tab-3">
           <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -222,30 +201,6 @@
       </div>
     </section>
 
-    <script>
-      const tabs = document.querySelectorAll(".info-box [role='tab']");
-      const panels = document.querySelectorAll(".info-box [role='tabpanel']");
-
-      for (i = 0; i < tabs.length; i++) {
-        const tab = tabs[i];
-        setTabHandler(tab, i);
-      }
-
-      function setTabHandler(tab, tabPos) {
-        tab.onclick = function () {
-          for (i = 0; i < tabs.length; i++) {
-            tabs[i].setAttribute("aria-selected", false);
-          }
-
-          tab.setAttribute("aria-selected", true);
-
-          for (i = 0; i < panels.length; i++) {
-            panels[i].className = "hidden";
-          }
-
-          panels[tabPos].className = "";
-        };
-      }
-    </script>
+    <script src="tabs-manual.js"></script>
   </body>
 </html>

--- a/css/css-layout/practical-positioning-examples/fixed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/fixed-info-box.html
@@ -45,7 +45,7 @@
         width: 150px;
       }
 
-      .info-box li a {
+      .info-box [role="tab"] {
         display: inline-block;
         text-decoration: none;
         width: 100%;
@@ -56,18 +56,18 @@
         font-weight: bold;
       }
 
-      .info-box li a:focus,
-      li a:hover {
+      .info-box [role="tab"]:focus,
+      .info-box [role="tab"]:hover {
+        background-color: #b6000099;
+        color: white;
+      }
+
+      .info-box [role="tab"][aria-selected="true"] {
         background-color: #b60000;
         color: white;
       }
 
-      .info-box li a.active-tab {
-        background-color: #b60000;
-        color: white;
-      }
-
-      /* styling info-box tabs */
+      /* styling info-box panles */
 
       .info-box .panels {
         clear: both;
@@ -75,7 +75,7 @@
         height: 352px;
       }
 
-      .info-box article {
+      .info-box [role="tabpanel"] {
         background-color: #b60000;
         color: white;
         position: absolute;
@@ -85,8 +85,8 @@
         left: 0;
       }
 
-      .info-box .active-panel {
-        z-index: 1;
+      .info-box [role="tabpanel"].hidden {
+        display: none;
       }
 
       /* Styling our fake content */
@@ -139,14 +139,44 @@
 
     <section class="info-box">
       <ul>
-        <li><a href="#" class="active-tab">Tab 1</a></li>
-        <li><a href="#">Tab 2</a></li>
-        <li><a href="#">Tab 3</a></li>
+        <li>
+          <button
+            id="tab-1"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tabpanel-1"
+          >
+            Tab 1
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-2"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-2"
+          >
+            Tab 2
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-3"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-3"
+          >
+            Tab 3
+          </button>
+        </li>
       </ul>
-      <div class="panels">
-        <article class="active-panel">
-          <h2>The first tab</h2>
 
+      <div class="panels">
+        <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
+          <h2>The first tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
@@ -157,23 +187,32 @@
             at sem. Aliquam ut porttitor urna. Nulla facilisi.
           </p>
         </article>
-        <article>
-          <h2>The second tab</h2>
 
+        <article
+          id="tabpanel-2"
+          role="tabpanel"
+          aria-labelledby="tab-2"
+          class="hidden"
+        >
+          <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
             very exciting all the same.
           </p>
         </article>
-        <article>
-          <h2>The third tab</h2>
 
+        <article
+          id="tabpanel-3"
+          role="tabpanel"
+          aria-labelledby="tab-3"
+          class="hidden"
+        >
+          <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
             augue. And now an ordered list: how exciting!
           </p>
-
           <ol>
             <li>dui neque eleifend lorem, a auctor libero turpis at sem.</li>
             <li>Aliquam ut porttitor urna.</li>
@@ -184,27 +223,27 @@
     </section>
 
     <script>
-      var tabs = document.querySelectorAll(".info-box li a");
-      var panels = document.querySelectorAll(".info-box article");
+      const tabs = document.querySelectorAll(".info-box [role='tab']");
+      const panels = document.querySelectorAll(".info-box [role='tabpanel']");
 
       for (i = 0; i < tabs.length; i++) {
-        var tab = tabs[i];
+        const tab = tabs[i];
         setTabHandler(tab, i);
       }
 
       function setTabHandler(tab, tabPos) {
         tab.onclick = function () {
           for (i = 0; i < tabs.length; i++) {
-            tabs[i].className = "";
+            tabs[i].setAttribute("aria-selected", false);
           }
 
-          tab.className = "active-tab";
+          tab.setAttribute("aria-selected", true);
 
           for (i = 0; i < panels.length; i++) {
-            panels[i].className = "";
+            panels[i].className = "hidden";
           }
 
-          panels[tabPos].className = "active-panel";
+          panels[tabPos].className = "";
         };
       }
     </script>

--- a/css/css-layout/practical-positioning-examples/hidden-info-panel-start.html
+++ b/css/css-layout/practical-positioning-examples/hidden-info-panel-start.html
@@ -14,8 +14,7 @@
       id="menu-button"
       aria-haspopup="true"
       aria-controls="info-panel"
-      aria-expanded="false"
-    >
+      aria-expanded="false">
       ❔
     </button>
 
@@ -27,8 +26,8 @@
       <ol>
         <li>It has a really cool slide-out information panel.</li>
         <li>
-          This information panel uses a combination of fixed positioning and a CSS
-          transition for the smooth sliding.
+          This information panel uses a combination of fixed positioning and a
+          CSS transition for the smooth sliding.
         </li>
         <li>
           Using JavaScript this information panel is brought in and out of the
@@ -36,5 +35,6 @@
         </li>
       </ol>
     </aside>
+    <script></script>
   </body>
 </html>

--- a/css/css-layout/practical-positioning-examples/hidden-info-panel-start.html
+++ b/css/css-layout/practical-positioning-examples/hidden-info-panel-start.html
@@ -7,28 +7,32 @@
 
     <style></style>
   </head>
+
   <body>
-    <label for="toggle">❔</label>
-    <input type="checkbox" id="toggle" />
-    <aside>
+    <button
+      type="button"
+      id="menu-button"
+      aria-haspopup="true"
+      aria-controls="info-panel"
+      aria-expanded="false"
+    >
+      ❔
+    </button>
+
+    <aside id="info-panel" aria-labelledby="menu-button">
       <h2>Information</h2>
 
       <p>Some very important information about your app:</p>
 
       <ol>
-        <li>It has a really cool slide-out information box.</li>
+        <li>It has a really cool slide-out information panel.</li>
         <li>
-          This information box uses a combination of fixed positioning and a CSS
+          This information panel uses a combination of fixed positioning and a CSS
           transition for the smooth sliding.
         </li>
         <li>
-          It also uses a cool technique called the
-          <a href="https://css-tricks.com/the-checkbox-hack/">checkbox hack</a>.
-        </li>
-        <li>
-          This allows you to create a nice "toggle on/toggle off" UI effect
-          without using any JavaScript, which will work in IE9 and above (the
-          smooth transition will work in IE10 and above.)
+          Using JavaScript this information panel is brought in and out of the
+          view.
         </li>
       </ol>
     </aside>

--- a/css/css-layout/practical-positioning-examples/hidden-info-panel.html
+++ b/css/css-layout/practical-positioning-examples/hidden-info-panel.html
@@ -46,8 +46,7 @@
       id="menu-button"
       aria-haspopup="true"
       aria-controls="info-panel"
-      aria-expanded="false"
-    >
+      aria-expanded="false">
       ❔
     </button>
 
@@ -59,8 +58,8 @@
       <ol>
         <li>It has a really cool slide-out information panel.</li>
         <li>
-          This information panel uses a combination of fixed positioning and a CSS
-          transition for the smooth sliding.
+          This information panel uses a combination of fixed positioning and a
+          CSS transition for the smooth sliding.
         </li>
         <li>
           Using JavaScript this information panel is brought in and out of the

--- a/css/css-layout/practical-positioning-examples/hidden-info-panel.html
+++ b/css/css-layout/practical-positioning-examples/hidden-info-panel.html
@@ -6,25 +6,20 @@
     <title>Hidden info panel</title>
 
     <style>
-      /* || Checkbox hack to control information box display */
-
-      label[for="toggle"] {
-        font-size: 3rem;
+      #menu-button {
         position: absolute;
-        top: 4px;
-        right: 5px;
+        top: 0.5rem;
+        right: 0.5rem;
         z-index: 1;
+
+        font-size: 3rem;
         cursor: pointer;
+        border: none;
+        background-color: transparent;
       }
 
-      input[type="checkbox"] {
-        position: absolute;
-        top: -100px;
-      }
-
-      /* information box styling */
-
-      aside {
+      /* information panel styling */
+      #info-panel {
         background-color: #a60000;
         color: white;
 
@@ -36,40 +31,52 @@
         top: 0;
         right: -370px;
 
-        transition: 0.6s all;
+        transition: 0.6s right ease-out;
       }
 
-      /* Second part of the checkbox hack — the checked state */
-
-      input[type="checkbox"]:checked + aside {
+      #info-panel.open {
         right: 0px;
       }
     </style>
   </head>
+
   <body>
-    <label for="toggle">❔</label>
-    <input type="checkbox" id="toggle" />
-    <aside>
+    <button
+      type="button"
+      id="menu-button"
+      aria-haspopup="true"
+      aria-controls="info-panel"
+      aria-expanded="false"
+    >
+      ❔
+    </button>
+
+    <aside id="info-panel" aria-labelledby="menu-button">
       <h2>Information</h2>
 
       <p>Some very important information about your app:</p>
 
       <ol>
-        <li>It has a really cool slide-out information box.</li>
+        <li>It has a really cool slide-out information panel.</li>
         <li>
-          This information box uses a combination of fixed positioning and a CSS
+          This information panel uses a combination of fixed positioning and a CSS
           transition for the smooth sliding.
         </li>
         <li>
-          It also uses a cool technique called the
-          <a href="https://css-tricks.com/the-checkbox-hack/">checkbox hack</a>.
-        </li>
-        <li>
-          This allows you to create a nice "toggle on/toggle off" UI effect
-          without using any JavaScript, which will work in IE9 and above (the
-          smooth transition will work in IE10 and above.)
+          Using JavaScript this information panel is brought in and out of the
+          view.
         </li>
       </ol>
     </aside>
+
+    <script>
+      const button = document.querySelector("#menu-button");
+      const panel = document.querySelector("#info-panel");
+
+      button.addEventListener("click", () => {
+        panel.classList.toggle("open");
+        button.setAttribute("aria-expanded", panel.classList.contains("open"));
+      });
+    </script>
   </body>
 </html>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
@@ -9,41 +9,36 @@
 
   <body>
     <section class="info-box">
-      <ul>
-        <li>
-          <button
-            id="tab-1"
-            type="button"
-            role="tab"
-            aria-selected="true"
-            aria-controls="tabpanel-1"
-          >
-            Tab 1
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-2"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-2"
-          >
-            Tab 2
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-3"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-3"
-          >
-            Tab 3
-          </button>
-        </li>
-      </ul>
+      <div role="tablist" class="manual">
+        <button
+          id="tab-1"
+          type="button"
+          role="tab"
+          aria-selected="true"
+          aria-controls="tabpanel-1"
+        >
+          <span>Tab 1</span>
+        </button>
+
+        <button
+          id="tab-2"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-2"
+        >
+          <span>Tab 2</span>
+        </button>
+        <button
+          id="tab-3"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-3"
+        >
+          <span>Tab 3</span>
+        </button>
+      </div>
 
       <div class="panels">
         <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
@@ -59,12 +54,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-2"
-          role="tabpanel"
-          aria-labelledby="tab-2"
-          class="hidden"
-        >
+        <article id="tabpanel-2" role="tabpanel" aria-labelledby="tab-2">
           <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
@@ -72,12 +62,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-3"
-          role="tabpanel"
-          aria-labelledby="tab-3"
-          class="hidden"
-        >
+        <article id="tabpanel-3" role="tabpanel" aria-labelledby="tab-3">
           <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -93,6 +78,6 @@
       </div>
     </section>
 
-    <script></script>
+    <script src="tabs-manual.js"></script>
   </body>
 </html>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
@@ -15,8 +15,7 @@
           type="button"
           role="tab"
           aria-selected="true"
-          aria-controls="tabpanel-1"
-        >
+          aria-controls="tabpanel-1">
           <span>Tab 1</span>
         </button>
 
@@ -25,8 +24,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-2"
-        >
+          aria-controls="tabpanel-2">
           <span>Tab 2</span>
         </button>
         <button
@@ -34,8 +32,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-3"
-        >
+          aria-controls="tabpanel-3">
           <span>Tab 3</span>
         </button>
       </div>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box-start.html
@@ -6,17 +6,48 @@
     <title>Tabbed info box</title>
     <style></style>
   </head>
+
   <body>
     <section class="info-box">
       <ul>
-        <li><a href="#" class="active-tab">Tab 1</a></li>
-        <li><a href="#">Tab 2</a></li>
-        <li><a href="#">Tab 3</a></li>
+        <li>
+          <button
+            id="tab-1"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tabpanel-1"
+          >
+            Tab 1
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-2"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-2"
+          >
+            Tab 2
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-3"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-3"
+          >
+            Tab 3
+          </button>
+        </li>
       </ul>
-      <div class="panels">
-        <article class="active-panel">
-          <h2>The first tab</h2>
 
+      <div class="panels">
+        <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
+          <h2>The first tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
@@ -27,23 +58,32 @@
             at sem. Aliquam ut porttitor urna. Nulla facilisi.
           </p>
         </article>
-        <article>
-          <h2>The second tab</h2>
 
+        <article
+          id="tabpanel-2"
+          role="tabpanel"
+          aria-labelledby="tab-2"
+          class="hidden"
+        >
+          <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
             very exciting all the same.
           </p>
         </article>
-        <article>
-          <h2>The third tab</h2>
 
+        <article
+          id="tabpanel-3"
+          role="tabpanel"
+          aria-labelledby="tab-3"
+          class="hidden"
+        >
+          <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
             augue. And now an ordered list: how exciting!
           </p>
-
           <ol>
             <li>dui neque eleifend lorem, a auctor libero turpis at sem.</li>
             <li>Aliquam ut porttitor urna.</li>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box.html
@@ -24,41 +24,34 @@
       .info-box {
         width: 452px;
         height: 400px;
-        margin: 20px auto 0;
+        margin: 1.25rem auto 0;
       }
 
       /* styling info-box tabs */
 
-      .info-box ul {
-        border: 1px solid #b60000;
-        overflow: hidden;
-        height: 50px;
-        margin: 0;
-        padding: 0;
-      }
-
-      .info-box li {
-        float: left;
-        list-style-type: none;
-        width: 150px;
+      .info-box [role="tablist"] {
+        min-width: 100%;
+        display: flex;
       }
 
       .info-box [role="tab"] {
         display: inline-block;
+        padding: 0 1rem 0 1rem;
         text-decoration: none;
-        width: 100%;
-        line-height: 50px;
+        line-height: 3rem;
         background: white;
         color: #b60000;
         text-align: center;
         font-weight: bold;
         border: none;
+        outline: none;
       }
 
-      .info-box [role="tab"]:focus,
-      .info-box [role="tab"]:hover {
-        background-color: #b6000099;
-        color: white;
+      .info-box [role="tab"]:focus span,
+      .info-box [role="tab"]:hover span {
+        outline: 1px solid blue;
+        outline-offset: 6px;
+        border-radius: 4px;
       }
 
       .info-box [role="tab"][aria-selected="true"] {
@@ -78,13 +71,13 @@
         background-color: #b60000;
         color: white;
         position: absolute;
-        padding: 10px 20px;
+        padding: 0.8rem 1.2rem;
         height: 352px;
         top: 0;
         left: 0;
       }
 
-      .info-box [role="tabpanel"].hidden {
+      .info-box [role="tabpanel"].is-hidden {
         display: none;
       }
     </style>
@@ -92,41 +85,36 @@
 
   <body>
     <section class="info-box">
-      <ul>
-        <li>
-          <button
-            id="tab-1"
-            type="button"
-            role="tab"
-            aria-selected="true"
-            aria-controls="tabpanel-1"
-          >
-            Tab 1
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-2"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-2"
-          >
-            Tab 2
-          </button>
-        </li>
-        <li>
-          <button
-            id="tab-3"
-            type="button"
-            role="tab"
-            aria-selected="false"
-            aria-controls="tabpanel-3"
-          >
-            Tab 3
-          </button>
-        </li>
-      </ul>
+      <div role="tablist" class="manual">
+        <button
+          id="tab-1"
+          type="button"
+          role="tab"
+          aria-selected="true"
+          aria-controls="tabpanel-1"
+        >
+          <span>Tab 1</span>
+        </button>
+
+        <button
+          id="tab-2"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-2"
+        >
+          <span>Tab 2</span>
+        </button>
+        <button
+          id="tab-3"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tabpanel-3"
+        >
+          <span>Tab 3</span>
+        </button>
+      </div>
 
       <div class="panels">
         <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
@@ -142,12 +130,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-2"
-          role="tabpanel"
-          aria-labelledby="tab-2"
-          class="hidden"
-        >
+        <article id="tabpanel-2" role="tabpanel" aria-labelledby="tab-2">
           <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
@@ -155,12 +138,7 @@
           </p>
         </article>
 
-        <article
-          id="tabpanel-3"
-          role="tabpanel"
-          aria-labelledby="tab-3"
-          class="hidden"
-        >
+        <article id="tabpanel-3" role="tabpanel" aria-labelledby="tab-3">
           <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -176,30 +154,6 @@
       </div>
     </section>
 
-    <script>
-      const tabs = document.querySelectorAll(".info-box [role='tab']");
-      const panels = document.querySelectorAll(".info-box [role='tabpanel']");
-
-      for (i = 0; i < tabs.length; i++) {
-        const tab = tabs[i];
-        setTabHandler(tab, i);
-      }
-
-      function setTabHandler(tab, tabPos) {
-        tab.onclick = function () {
-          for (i = 0; i < tabs.length; i++) {
-            tabs[i].setAttribute("aria-selected", false);
-          }
-
-          tab.setAttribute("aria-selected", true);
-
-          for (i = 0; i < panels.length; i++) {
-            panels[i].className = "hidden";
-          }
-
-          panels[tabPos].className = "";
-        };
-      }
-    </script>
+    <script src="tabs-manual.js"></script>
   </body>
 </html>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box.html
@@ -35,15 +35,12 @@
       }
 
       .info-box [role="tab"] {
-        display: inline-block;
-        padding: 0 1rem 0 1rem;
-        text-decoration: none;
-        line-height: 3rem;
-        background: white;
-        color: #b60000;
-        text-align: center;
-        font-weight: bold;
         border: none;
+        background: white;
+        padding: 0 1rem 0 1rem;
+        line-height: 3rem;
+        color: #b60000;
+        font-weight: bold;
         outline: none;
       }
 
@@ -62,9 +59,9 @@
       /* styling info-box panels */
 
       .info-box .panels {
+        height: 352px;
         clear: both;
         position: relative;
-        height: 352px;
       }
 
       .info-box [role="tabpanel"] {
@@ -91,8 +88,7 @@
           type="button"
           role="tab"
           aria-selected="true"
-          aria-controls="tabpanel-1"
-        >
+          aria-controls="tabpanel-1">
           <span>Tab 1</span>
         </button>
 
@@ -101,8 +97,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-2"
-        >
+          aria-controls="tabpanel-2">
           <span>Tab 2</span>
         </button>
         <button
@@ -110,8 +105,7 @@
           type="button"
           role="tab"
           aria-selected="false"
-          aria-controls="tabpanel-3"
-        >
+          aria-controls="tabpanel-3">
           <span>Tab 3</span>
         </button>
       </div>

--- a/css/css-layout/practical-positioning-examples/tabbed-info-box.html
+++ b/css/css-layout/practical-positioning-examples/tabbed-info-box.html
@@ -43,7 +43,7 @@
         width: 150px;
       }
 
-      .info-box li a {
+      .info-box [role="tab"] {
         display: inline-block;
         text-decoration: none;
         width: 100%;
@@ -52,15 +52,16 @@
         color: #b60000;
         text-align: center;
         font-weight: bold;
+        border: none;
       }
 
-      .info-box li a:focus,
-      .info-box li a:hover {
-        background-color: #b60000;
+      .info-box [role="tab"]:focus,
+      .info-box [role="tab"]:hover {
+        background-color: #b6000099;
         color: white;
       }
 
-      .info-box li a.active-tab {
+      .info-box [role="tab"][aria-selected="true"] {
         background-color: #b60000;
         color: white;
       }
@@ -73,7 +74,7 @@
         height: 352px;
       }
 
-      .info-box article {
+      .info-box [role="tabpanel"] {
         background-color: #b60000;
         color: white;
         position: absolute;
@@ -83,22 +84,53 @@
         left: 0;
       }
 
-      .info-box .active-panel {
-        z-index: 1;
+      .info-box [role="tabpanel"].hidden {
+        display: none;
       }
     </style>
   </head>
+
   <body>
     <section class="info-box">
       <ul>
-        <li><a href="#" class="active-tab">Tab 1</a></li>
-        <li><a href="#">Tab 2</a></li>
-        <li><a href="#">Tab 3</a></li>
+        <li>
+          <button
+            id="tab-1"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tabpanel-1"
+          >
+            Tab 1
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-2"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-2"
+          >
+            Tab 2
+          </button>
+        </li>
+        <li>
+          <button
+            id="tab-3"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tabpanel-3"
+          >
+            Tab 3
+          </button>
+        </li>
       </ul>
-      <div class="panels">
-        <article class="active-panel">
-          <h2>The first tab</h2>
 
+      <div class="panels">
+        <article id="tabpanel-1" role="tabpanel" aria-labelledby="tab-1">
+          <h2>The first tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
@@ -109,23 +141,32 @@
             at sem. Aliquam ut porttitor urna. Nulla facilisi.
           </p>
         </article>
-        <article>
-          <h2>The second tab</h2>
 
+        <article
+          id="tabpanel-2"
+          role="tabpanel"
+          aria-labelledby="tab-2"
+          class="hidden"
+        >
+          <h2>The second tab</h2>
           <p>
             This tab hasn't got any Lorem Ipsum in it. But the content isn't
             very exciting all the same.
           </p>
         </article>
-        <article>
-          <h2>The third tab</h2>
 
+        <article
+          id="tabpanel-3"
+          role="tabpanel"
+          aria-labelledby="tab-3"
+          class="hidden"
+        >
+          <h2>The third tab</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Pellentesque turpis nibh, porttitor nec venenatis eu, pulvinar in
             augue. And now an ordered list: how exciting!
           </p>
-
           <ol>
             <li>dui neque eleifend lorem, a auctor libero turpis at sem.</li>
             <li>Aliquam ut porttitor urna.</li>
@@ -136,27 +177,27 @@
     </section>
 
     <script>
-      var tabs = document.querySelectorAll(".info-box li a");
-      var panels = document.querySelectorAll(".info-box article");
+      const tabs = document.querySelectorAll(".info-box [role='tab']");
+      const panels = document.querySelectorAll(".info-box [role='tabpanel']");
 
       for (i = 0; i < tabs.length; i++) {
-        var tab = tabs[i];
+        const tab = tabs[i];
         setTabHandler(tab, i);
       }
 
       function setTabHandler(tab, tabPos) {
         tab.onclick = function () {
           for (i = 0; i < tabs.length; i++) {
-            tabs[i].className = "";
+            tabs[i].setAttribute("aria-selected", false);
           }
 
-          tab.className = "active-tab";
+          tab.setAttribute("aria-selected", true);
 
           for (i = 0; i < panels.length; i++) {
-            panels[i].className = "";
+            panels[i].className = "hidden";
           }
 
-          panels[tabPos].className = "active-panel";
+          panels[tabPos].className = "";
         };
       }
     </script>

--- a/css/css-layout/practical-positioning-examples/tabs-manual.js
+++ b/css/css-layout/practical-positioning-examples/tabs-manual.js
@@ -1,0 +1,138 @@
+/*
+ *   This content is licensed according to the W3C Software License at
+ *   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ *   File:   tabs-manual.js
+ *
+ *   Desc:   Tablist widget that implements ARIA Authoring Practices
+ */
+
+"use strict";
+
+class TabsManual {
+  constructor(groupNode) {
+    this.tablistNode = groupNode;
+
+    this.tabs = [];
+
+    this.firstTab = null;
+    this.lastTab = null;
+
+    this.tabs = Array.from(this.tablistNode.querySelectorAll("[role=tab]"));
+    this.tabpanels = [];
+
+    for (let i = 0; i < this.tabs.length; i += 1) {
+      const tab = this.tabs[i];
+      const tabpanel = document.getElementById(
+        tab.getAttribute("aria-controls")
+      );
+
+      tab.tabIndex = -1;
+      tab.setAttribute("aria-selected", "false");
+      this.tabpanels.push(tabpanel);
+
+      tab.addEventListener("keydown", this.onKeydown.bind(this));
+      tab.addEventListener("click", this.onClick.bind(this));
+
+      if (!this.firstTab) {
+        this.firstTab = tab;
+      }
+      this.lastTab = tab;
+    }
+
+    this.setSelectedTab(this.firstTab);
+  }
+
+  setSelectedTab(currentTab) {
+    for (let i = 0; i < this.tabs.length; i += 1) {
+      const tab = this.tabs[i];
+      if (currentTab === tab) {
+        tab.setAttribute("aria-selected", "true");
+        tab.removeAttribute("tabindex");
+        this.tabpanels[i].classList.remove("is-hidden");
+      } else {
+        tab.setAttribute("aria-selected", "false");
+        tab.tabIndex = -1;
+        this.tabpanels[i].classList.add("is-hidden");
+      }
+    }
+  }
+
+  moveFocusToTab(currentTab) {
+    currentTab.focus();
+  }
+
+  moveFocusToPreviousTab(currentTab) {
+    let index;
+
+    if (currentTab === this.firstTab) {
+      this.moveFocusToTab(this.lastTab);
+    } else {
+      index = this.tabs.indexOf(currentTab);
+      this.moveFocusToTab(this.tabs[index - 1]);
+    }
+  }
+
+  moveFocusToNextTab(currentTab) {
+    let index;
+
+    if (currentTab === this.lastTab) {
+      this.moveFocusToTab(this.firstTab);
+    } else {
+      index = this.tabs.indexOf(currentTab);
+      this.moveFocusToTab(this.tabs[index + 1]);
+    }
+  }
+
+  /* EVENT HANDLERS */
+
+  onKeydown(event) {
+    const tgt = event.currentTarget,
+      flag = false;
+
+    switch (event.key) {
+      case "ArrowLeft":
+        this.moveFocusToPreviousTab(tgt);
+        flag = true;
+        break;
+
+      case "ArrowRight":
+        this.moveFocusToNextTab(tgt);
+        flag = true;
+        break;
+
+      case "Home":
+        this.moveFocusToTab(this.firstTab);
+        flag = true;
+        break;
+
+      case "End":
+        this.moveFocusToTab(this.lastTab);
+        flag = true;
+        break;
+
+      default:
+        break;
+    }
+
+    if (flag) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  }
+
+  // Since this example uses buttons for the tabs, the click onr also is activated
+  // with the space and enter keys
+  onClick(event) {
+    this.setSelectedTab(event.currentTarget);
+  }
+}
+
+// Initialize tablist
+
+window.addEventListener("load", function () {
+  const tablists = document.querySelectorAll("[role=tablist].manual");
+  for (let i = 0; i < tablists.length; i++) {
+    new TabsManual(tablists[i]);
+  }
+});

--- a/css/css-layout/practical-positioning-examples/tabs-manual.js
+++ b/css/css-layout/practical-positioning-examples/tabs-manual.js
@@ -87,8 +87,8 @@ class TabsManual {
   /* EVENT HANDLERS */
 
   onKeydown(event) {
-    const tgt = event.currentTarget,
-      flag = false;
+    const tgt = event.currentTarget;
+    let flag = false;
 
     switch (event.key) {
       case "ArrowLeft":


### PR DESCRIPTION
Part of the fix for:
- https://github.com/mdn/content/issues/24806
- https://github.com/mdn/content/issues/30473

The PR:
- uses buttons instead of links and checkboxes. The examples could use the `tab` and `space`/`enter` buttons.
- adds ARIA attributes

To test, open the HTML files in a browser.

I'll submit content PR once this is reviewed and finalized.