### PR TITLE
fix: incorrect error example

### DIFF
--- a/javascript/introduction-to-js-1/troubleshooting/number-game-errors.html
+++ b/javascript/introduction-to-js-1/troubleshooting/number-game-errors.html
@@ -55,7 +55,7 @@
 
   function checkGuess() {
 
-    const userGuess = Number(guessField.value);
+    let userGuess = Number(guessField.value);
     if(guessCount === 1) {
       guesses.textContent = 'Previous guesses: ';
     }


### PR DESCRIPTION
### Description

Changed const to let

### Motivation

Currently the "other common errors" section's subsection "The program always says you've won, regardless of the guess you enter" is incorrect as instead of the described behavior it throws an error. (TypeError: invalid assignment to const 'userGuess')

(It might be better to keep this as const and change docs instead to reflect the current behavior, but I'm not experienced enough to feel comfortable writing docs)

### Additional details

Docs related to this file:

https://github.com/mdn/content/blob/b67fd42cfb01dd4d9504c4182b462851588a0bad/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md#L4

