### PR TITLE
Display #000 colour input box highlight on forcus

### DIFF
--- a/html/forms/your-first-HTML-form/first-form-styled.html
+++ b/html/forms/your-first-HTML-form/first-form-styled.html
@@ -46,8 +46,10 @@
 
 			input:focus,
 			textarea:focus {
+				/* Set the outline width and style */
+				outline-style: solid;
 				/* To give a little highlight on active elements */
-				border-color: #000;
+				outline-color: #000;
 			}
 
 			textarea {


### PR DESCRIPTION
This commit is related to the following:
[https://github.com/mdn/content/pull/36103](https://github.com/mdn/content/pull/36103/commits)

Since the outline colour in which the input elements are highlighted differs from operation systems - blue by default on Mac OS, black (rgb(16, 16, 16)) on WIndows - this commit is to apply the same outline colour across those operation systems.

This implementation was tested on Chrome and Firefox.