### PR TITLE
Add title attributes to match task

### DIFF
--- a/html/introduction-to-html/tasks/advanced-text/marking.md
+++ b/html/introduction-to-html/tasks/advanced-text/marking.md
@@ -38,13 +38,13 @@ The finished code should look like this:
 
 <blockquote cite="https://developer.mozilla.org/en-US/docs/Learn/Accessibility">
   <p>
-    <abbr>HTML</abbr>, Hypertext Markup Language is by default accessible, if
+    <abbr title="Hypertext Markup Language">HTML</abbr>, Hypertext Markup Language is by default accessible, if
     used correctly.
   </p>
 </blockquote>
 
 <p>
-  <abbr>CSS</abbr>, Cascading Style Sheets, can also be used to make web pages
+  <abbr title="Cascading Style Sheets">CSS</abbr>, Cascading Style Sheets, can also be used to make web pages
   more, or less, accessible.
 </p>
 


### PR DESCRIPTION
## What?

I've added title attributes to the two abbreviation tags (one for HTML and one for CSS), referencing their expansions.

## Why?

These changes reflect the requirements of the task found [here](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Test_your_skills/Advanced_HTML_text).