### PR TITLE
Fix "ReferenceError: catName is not defined"

### DIFF
--- a/javascript/oojs/tasks/object-basics/object-basics1-download.html
+++ b/javascript/oojs/tasks/object-basics/object-basics1-download.html
@@ -46,7 +46,7 @@
     let para1 = document.createElement('p');
     let para2 = document.createElement('p');
 
-    para1.textContent = `The cat's name is ${ catName }.`;
+    para1.textContent = `The cat's name is ${ cat.catName }.`;
     para2.textContent = `The cat's color is ${ cat.color }.`;
 
     section.appendChild(para1);

--- a/javascript/oojs/tasks/object-basics/object-basics1.html
+++ b/javascript/oojs/tasks/object-basics/object-basics1.html
@@ -42,7 +42,7 @@ const cat = {
 let para1 = document.createElement('p');
 let para2 = document.createElement('p');
 
-para1.textContent = `The cat's name is ${ catName }.`;
+para1.textContent = `The cat's name is ${ cat.catName }.`;
 para2.textContent = `The cat's color is ${ cat.color }.`;
 
 section.appendChild(para1);


### PR DESCRIPTION
For Object Basics 1 exercise, there's a
reference error omitted from lines 44-45 of each
file. Fix reference error by including class
name "cat" to access key "catName".




