### PR TITLE
fix: Correct city name in items-sold.html

### DIFF
--- a/html/tables/advanced/items-sold-headers.html
+++ b/html/tables/advanced/items-sold-headers.html
@@ -37,12 +37,12 @@
           <td headers="antwerp belgium accessories rings">23</td>
         </tr>
         <tr>
-          <th id="gent" headers="belgium">Gent</th>
-          <td headers="gent belgium clothes trousers">46</td>
-          <td headers="gent belgium clothes skirts">18</td>
-          <td headers="gent belgium clothes dresses">50</td>
-          <td headers="gent belgium accessories bracelets">61</td>
-          <td headers="gent belgium accessories rings">15</td>
+          <th id="ghent" headers="belgium">Ghent</th>
+          <td headers="ghent belgium clothes trousers">46</td>
+          <td headers="ghent belgium clothes skirts">18</td>
+          <td headers="ghent belgium clothes dresses">50</td>
+          <td headers="ghent belgium accessories bracelets">61</td>
+          <td headers="ghent belgium accessories rings">15</td>
         </tr>
         <tr>
           <th id="brussels" headers="belgium">Brussels</th>

--- a/html/tables/advanced/items-sold-scope.html
+++ b/html/tables/advanced/items-sold-scope.html
@@ -37,7 +37,7 @@
           <td>23</td>
         </tr>
         <tr>
-          <th scope="row">Gent</th>
+          <th scope="row">Ghent</th>
           <td>46</td>
           <td>18</td>
           <td>50</td>

--- a/html/tables/advanced/items-sold.html
+++ b/html/tables/advanced/items-sold.html
@@ -37,7 +37,7 @@
           <td>23</td>
         </tr>
         <tr>
-          <th>Gent</th>
+          <th>Ghent</th>
           <td>46</td>
           <td>18</td>
           <td>50</td>


### PR DESCRIPTION
**Issue**
A typo issue is found when browser the learning modules for [html tables](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Table_accessibility#playing_with_scope_and_headers).

**Reason for change**
Correcting a typo issue found in the learner script. 
This is inline with the changes made in this PR [#40052](https://github.com/mdn/content/pull/40052)
