### PR TITLE
Use range syntax for media query to match guide

### DIFF
--- a/html/multimedia-and-embedding/responsive-images/responsive.html
+++ b/html/multimedia-and-embedding/responsive-images/responsive.html
@@ -57,7 +57,7 @@
 
         <img srcset="elva-fairy-480w.jpg 480w,
                      elva-fairy-800w.jpg 800w"
-               sizes="(width <= 600px) 480px,
+             sizes="(width <= 600px) 480px,
                     800px"
              src="elva-fairy-800w.jpg" alt="Elva dressed as a fairy">
 


### PR DESCRIPTION
The [mdn guide page](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images) that references this example has been updated ([see the diff here](https://github.com/mdn/content/commit/63cbf204323f117a2a80c7aa6273e50253ab9d07#diff-6a0732b6d626a317e5b1daad10313d51d23ffce404aa51187f7c9fa42917114aL141-L147)) so that its media query uses range syntax, see specifically its [resolution-switching](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images#resolution_switching_different_sizes) and [art direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images#art_direction) sections.

This PR updates the example to match the guide.