### PR TITLE
Fix: Change class attribute setting to classList.add

### DIFF
--- a/javascript/apis/document-manipulation/dom-example-manipulated.html
+++ b/javascript/apis/document-manipulation/dom-example-manipulated.html
@@ -40,7 +40,7 @@
       sect.appendChild(linkPara);
       linkPara.parentNode.removeChild(linkPara);
 
-      para.setAttribute('class', 'highlight');
+      para.classList.add("highlight");
     </script>
   </body>
 </html>


### PR DESCRIPTION
The article's prose(step 3) instructs using `para.classList.add("highlight")`, but the accompanying code sample or finished sample below uses `para.setAttribute('class', 'highlight');`.